### PR TITLE
⚡ Bolt: Optimize CartSummary recompositions using data class

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Use data classes for Jetpack Compose state objects
+**Learning:** Jetpack Compose recomposition uses structural equality. If a regular class (which uses identity-based equality via `Object.equals`) is used as a parameter for a Composable, the Composable will unnecessarily recompose every time a new instance of the class is created, even if all logical fields are identical.
+**Action:** Always use `data class` for state objects passed to Composables so that their `equals()` method compares structural content.

--- a/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
+++ b/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
@@ -43,10 +43,11 @@ import androidx.compose.ui.unit.dp
 // FIX: Make CartSummary a data class so equals() is structural.
 // ============================================================
 
-// ISSUE: Unstable class — uses identity-based equality (Object.equals),
-// causing recomposition even when the logical content is the same.
-// Making this a `data class` would fix the problem.
-class CartSummary(val itemCount: Int, val totalPrice: String)
+// ⚡ Bolt Optimization:
+// Changed to `data class` to provide structural equality instead of identity-based
+// equality (Object.equals). This prevents `CartBanner` from needlessly recomposing
+// every time its parent recomposes and creates a new instance with identical fields.
+data class CartSummary(val itemCount: Int, val totalPrice: String)
 
 @Composable
 fun ProductListScreen() {

--- a/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
+++ b/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
@@ -108,20 +108,15 @@ class RecompositionRegressionTest {
 
     @Test
     fun cartBanner_recomposesOnUnrelatedRefresh() {
-        // CURRENT BEHAVIOR (issue): Clicking refresh changes refreshCount,
+        // FIXED BEHAVIOR: Clicking refresh changes refreshCount,
         // which recomposes ProductListScreen. A new CartSummary(0, "$0.0")
-        // is created. Because CartSummary is NOT a data class, the new
-        // instance != the old instance (reference inequality), so
-        // CartBanner recomposes even though the cart content is unchanged.
+        // is created. Because CartSummary is a data class, the new
+        // instance == the old instance (structural equality), so
+        // CartBanner stays stable.
         composeTestRule.onNodeWithTag("refresh_button").performClick()
 
-        // ISSUE: CartBanner recomposes despite no logical change to the cart
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 1)
-
-        // FIX: If CartSummary were a `data class`, equals() would compare
-        // fields structurally. CartSummary(0, "$0.0") == CartSummary(0, "$0.0")
-        // would be true, and Compose would SKIP the recomposition.
-        // The fixed assertion would be: assertFirstComposition()
+        // FIXED: CartBanner stays stable when there is no logical change
+        composeTestRule.onNodeWithTag("cart_banner").assertStable()
     }
 
     // ============================================================
@@ -159,15 +154,9 @@ class RecompositionRegressionTest {
             composeTestRule.onNodeWithTag("refresh_button").performClick()
         }
 
-        // CURRENT BEHAVIOR (issue): CartBanner recomposes on EVERY parent
-        // recomposition because CartSummary is unstable. That's 5 total
-        // recompositions (2 from selects + 3 from refreshes).
-        // Budget: at most 5 -- bounded at 1:1 with parent recompositions.
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atMost = 5)
-
-        // FIX: With `data class CartSummary`, only the 2 select clicks
-        // would cause recomposition (the content actually changes).
-        // The fixed assertion would be: assertRecomposesExactly(2)
+        // FIXED: With `data class CartSummary`, only the 2 select clicks
+        // cause recomposition (the content actually changes).
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================
@@ -197,11 +186,9 @@ class RecompositionRegressionTest {
         // Footer stays stable due to strong skipping mode memoizing the lambda
         composeTestRule.onNodeWithTag("product_footer").assertStable()
 
-        // ISSUE: CartBanner recomposes on ALL 3 interactions (2 selects + 1 refresh)
-        // because each parent recomposition creates a new CartSummary instance.
-        // FIX: With `data class CartSummary`, only the 2 selects would cause
-        // recomposition. The fixed assertion would be: assertRecomposesExactly(2)
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 3)
+        // FIXED: With `data class CartSummary`, only the 2 selects cause
+        // recomposition.
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================


### PR DESCRIPTION
💡 What: Changed `CartSummary` from a regular `class` to a `data class` in `demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt`.

🎯 Why: In Jetpack Compose, state objects passed as parameters to Composables should use structural equality. A regular class uses identity-based equality (`Object.equals`), so every time a parent recomposes and creates a new instance of `CartSummary`, the child `CartBanner` needless recomposes, even when the data fields (`itemCount`, `totalPrice`) are completely identical. Changing it to a `data class` causes `equals()` to compare structural content instead, skipping unnecessary recompositions.

📊 Impact: Reduces `CartBanner` recompositions. It will now only recompose when its data actually changes, avoiding recompiles driven simply by parent recreations.

🔬 Measurement: Observe recomposition counts on the `CartBanner` composable. Previously, it recomposed on every parent recompose; it will now remain stable if its inputs are unchanged. Run Dejavu instrumented tests or UI tests tracking recomposition numbers.

---
*PR created automatically by Jules for task [13970855244932040762](https://jules.google.com/task/13970855244932040762) started by @himattm*