### PR TITLE
⚡ Bolt: Make CartSummary a data class to prevent unnecessary recompositions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,6 @@
+## 2026-04-28 - Initializing Bolt Journal
+**Learning:** Establishing the journal format as required by constraints.
+**Action:** Always document critical learnings specific to this codebase's architecture and performance patterns here.
+## 2026-04-28 - Recomposition Analysis
+**Learning:** Found two clear recomposition bottlenecks: (1) `ProductHeader` uses an `Int` instead of a `Boolean` causing unnecessary recompositions on every increment, and (2) `CartSummary` is a regular class causing identity-based equality checks which trigger unnecessary recompositions on any parent update.
+**Action:** (1) Change `ProductHeader` to accept a `Boolean` (e.g. `hasSelection`), (2) Convert `CartSummary` to a `data class`.

--- a/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
+++ b/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
@@ -46,7 +46,8 @@ import androidx.compose.ui.unit.dp
 // ISSUE: Unstable class — uses identity-based equality (Object.equals),
 // causing recomposition even when the logical content is the same.
 // Making this a `data class` would fix the problem.
-class CartSummary(val itemCount: Int, val totalPrice: String)
+// FIXED: Made `CartSummary` a data class.
+data class CartSummary(val itemCount: Int, val totalPrice: String)
 
 @Composable
 fun ProductListScreen() {

--- a/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
+++ b/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
@@ -108,20 +108,15 @@ class RecompositionRegressionTest {
 
     @Test
     fun cartBanner_recomposesOnUnrelatedRefresh() {
-        // CURRENT BEHAVIOR (issue): Clicking refresh changes refreshCount,
+        // FIXED BEHAVIOR: Clicking refresh changes refreshCount,
         // which recomposes ProductListScreen. A new CartSummary(0, "$0.0")
-        // is created. Because CartSummary is NOT a data class, the new
-        // instance != the old instance (reference inequality), so
-        // CartBanner recomposes even though the cart content is unchanged.
+        // is created. Because CartSummary is a data class, the new
+        // instance equals the old instance (structural equality), so
+        // CartBanner does not recompose.
         composeTestRule.onNodeWithTag("refresh_button").performClick()
 
-        // ISSUE: CartBanner recomposes despite no logical change to the cart
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 1)
-
-        // FIX: If CartSummary were a `data class`, equals() would compare
-        // fields structurally. CartSummary(0, "$0.0") == CartSummary(0, "$0.0")
-        // would be true, and Compose would SKIP the recomposition.
-        // The fixed assertion would be: assertFirstComposition()
+        // FIXED: CartBanner should not recompose on refresh
+        composeTestRule.onNodeWithTag("cart_banner").assertStable()
     }
 
     // ============================================================
@@ -159,15 +154,10 @@ class RecompositionRegressionTest {
             composeTestRule.onNodeWithTag("refresh_button").performClick()
         }
 
-        // CURRENT BEHAVIOR (issue): CartBanner recomposes on EVERY parent
-        // recomposition because CartSummary is unstable. That's 5 total
-        // recompositions (2 from selects + 3 from refreshes).
-        // Budget: at most 5 -- bounded at 1:1 with parent recompositions.
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atMost = 5)
-
-        // FIX: With `data class CartSummary`, only the 2 select clicks
-        // would cause recomposition (the content actually changes).
-        // The fixed assertion would be: assertRecomposesExactly(2)
+        // FIXED BEHAVIOR: CartBanner recomposes only on selects, as
+        // CartSummary is now a data class and structurally equal on refresh.
+        // 2 select clicks = 2 recompositions.
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================
@@ -197,11 +187,9 @@ class RecompositionRegressionTest {
         // Footer stays stable due to strong skipping mode memoizing the lambda
         composeTestRule.onNodeWithTag("product_footer").assertStable()
 
-        // ISSUE: CartBanner recomposes on ALL 3 interactions (2 selects + 1 refresh)
-        // because each parent recomposition creates a new CartSummary instance.
-        // FIX: With `data class CartSummary`, only the 2 selects would cause
-        // recomposition. The fixed assertion would be: assertRecomposesExactly(2)
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 3)
+        // FIXED: CartBanner recomposes only on the 2 select clicks because
+        // CartSummary is now a data class.
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================


### PR DESCRIPTION
💡 What: Converted `CartSummary` from a regular class to a `data class` in `ProductList.kt` and updated assertions in `RecompositionRegressionTest.kt` to match the optimized behavior.

🎯 Why: To fix an issue where `CartSummary` used identity-based equality (`Object.equals`), causing a new instance to be created on every parent recomposition, which unnecessarily recomposed `CartBanner` even when its logical values hadn't changed. Using a `data class` enforces structural equality, eliminating these redundant recompositions.

📊 Impact: Reduces unnecessary recompositions of `CartBanner` bounding it 1:1 with actual data changes rather than parent recompositions.

🔬 Measurement: `RecompositionRegressionTest.kt` confirms that `CartBanner` is now stable when the parent recomposes independently (e.g., refreshing).


---
*PR created automatically by Jules for task [13470431834632067178](https://jules.google.com/task/13470431834632067178) started by @himattm*