### PR TITLE
⚡ Bolt: Update CartSummary to data class

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-29 - Data classes and precise parameter scoping prevent unnecessary recompositions
+**Learning:** Using regular classes for UI state leads to identity-based equality checks, causing unnecessary recompositions. Similarly, passing broader state (e.g., an `Int` count) to a composable that only needs a derived boolean triggers recompositions on every state change.
+**Action:** Always use `data class` for state objects passed as parameters to ensure structural equality (`equals()`). Scope composable parameters to the smallest required type (e.g., passing a derived `Boolean` instead of the raw `Int` state) to minimize recompositions.

--- a/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
+++ b/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.unit.dp
 // ISSUE: Unstable class — uses identity-based equality (Object.equals),
 // causing recomposition even when the logical content is the same.
 // Making this a `data class` would fix the problem.
-class CartSummary(val itemCount: Int, val totalPrice: String)
+data class CartSummary(val itemCount: Int, val totalPrice: String)
 
 @Composable
 fun ProductListScreen() {

--- a/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
+++ b/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
@@ -108,20 +108,15 @@ class RecompositionRegressionTest {
 
     @Test
     fun cartBanner_recomposesOnUnrelatedRefresh() {
-        // CURRENT BEHAVIOR (issue): Clicking refresh changes refreshCount,
+        // FIXED BEHAVIOR: Clicking refresh changes refreshCount,
         // which recomposes ProductListScreen. A new CartSummary(0, "$0.0")
-        // is created. Because CartSummary is NOT a data class, the new
-        // instance != the old instance (reference inequality), so
-        // CartBanner recomposes even though the cart content is unchanged.
+        // is created. Because CartSummary is a data class, the new
+        // instance == the old instance (structural equality), so
+        // CartBanner skips recomposition.
         composeTestRule.onNodeWithTag("refresh_button").performClick()
 
-        // ISSUE: CartBanner recomposes despite no logical change to the cart
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 1)
-
-        // FIX: If CartSummary were a `data class`, equals() would compare
-        // fields structurally. CartSummary(0, "$0.0") == CartSummary(0, "$0.0")
-        // would be true, and Compose would SKIP the recomposition.
-        // The fixed assertion would be: assertFirstComposition()
+        // FIXED: CartBanner does not recompose
+        composeTestRule.onNodeWithTag("cart_banner").assertStable()
     }
 
     // ============================================================
@@ -159,15 +154,10 @@ class RecompositionRegressionTest {
             composeTestRule.onNodeWithTag("refresh_button").performClick()
         }
 
-        // CURRENT BEHAVIOR (issue): CartBanner recomposes on EVERY parent
-        // recomposition because CartSummary is unstable. That's 5 total
-        // recompositions (2 from selects + 3 from refreshes).
-        // Budget: at most 5 -- bounded at 1:1 with parent recompositions.
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atMost = 5)
-
-        // FIX: With `data class CartSummary`, only the 2 select clicks
-        // would cause recomposition (the content actually changes).
-        // The fixed assertion would be: assertRecomposesExactly(2)
+        // FIXED BEHAVIOR: CartBanner only recomposes when the cart content
+        // actually changes (the 2 selects), avoiding the 3 unnecessary
+        // recompositions from the refresh clicks.
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================
@@ -197,11 +187,9 @@ class RecompositionRegressionTest {
         // Footer stays stable due to strong skipping mode memoizing the lambda
         composeTestRule.onNodeWithTag("product_footer").assertStable()
 
-        // ISSUE: CartBanner recomposes on ALL 3 interactions (2 selects + 1 refresh)
-        // because each parent recomposition creates a new CartSummary instance.
-        // FIX: With `data class CartSummary`, only the 2 selects would cause
-        // recomposition. The fixed assertion would be: assertRecomposesExactly(2)
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 3)
+        // FIXED: CartBanner only recomposes on the 2 select interactions,
+        // avoiding the unnecessary recomposition on the refresh click.
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================


### PR DESCRIPTION
💡 What:
Changed `class CartSummary` to `data class CartSummary`.

🎯 Why:
Regular classes use reference equality (identity-based). When the parent component (`ProductListScreen`) recomposes due to an unrelated state change (`refreshCount`), it instantiates a new `CartSummary` object. Because it was a regular class, Compose saw a different instance and forced a recomposition of `CartBanner`, despite the actual data (item count, total price) remaining identical. Changing it to a `data class` enables structural equality (`equals()`), allowing Compose to skip the recomposition when the logical content is identical.

📊 Impact:
Eliminates unnecessary `CartBanner` recompositions when unrelated parent state changes occur. In the `performanceBudget_cartBannerOnMixedInteractions` test, recompositions were reduced from 5 to 2.

🔬 Measurement:
Verified via updated Dejavu test assertions in `RecompositionRegressionTest.kt`, checking `assertStable()` for `cartBanner` on unrelated refreshes, and explicitly testing expected bounded bounds.

---
*PR created automatically by Jules for task [4180045620163765414](https://jules.google.com/task/4180045620163765414) started by @himattm*