### PR TITLE
⚡ Bolt: Prevent unnecessary recompositions by using data class for state

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-10-24 - Unstable Classes Cause Unnecessary Recompositions
+**Learning:** In Jetpack Compose, using a standard class (not a `data class`) for state objects passed as parameters causes identity-based equality checks (`Object.equals`). This leads to unnecessary recompositions of child components when the parent recomposes for unrelated reasons, because every instance creation is seen as a new, different parameter.
+**Action:** Always use `data class` for state objects passed as parameters to ensure structural equality (`equals()`) instead of reference equality, thereby preventing unnecessary recompositions.

--- a/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
+++ b/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
@@ -43,10 +43,9 @@ import androidx.compose.ui.unit.dp
 // FIX: Make CartSummary a data class so equals() is structural.
 // ============================================================
 
-// ISSUE: Unstable class — uses identity-based equality (Object.equals),
-// causing recomposition even when the logical content is the same.
-// Making this a `data class` would fix the problem.
-class CartSummary(val itemCount: Int, val totalPrice: String)
+// FIXED: data class provides structural equality (equals() is generated based on fields).
+// This prevents recomposition when the parent recomposes but the data is logically identical.
+data class CartSummary(val itemCount: Int, val totalPrice: String)
 
 @Composable
 fun ProductListScreen() {

--- a/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
+++ b/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
@@ -108,20 +108,15 @@ class RecompositionRegressionTest {
 
     @Test
     fun cartBanner_recomposesOnUnrelatedRefresh() {
-        // CURRENT BEHAVIOR (issue): Clicking refresh changes refreshCount,
+        // FIXED BEHAVIOR: Clicking refresh changes refreshCount,
         // which recomposes ProductListScreen. A new CartSummary(0, "$0.0")
-        // is created. Because CartSummary is NOT a data class, the new
-        // instance != the old instance (reference inequality), so
-        // CartBanner recomposes even though the cart content is unchanged.
+        // is created. Because CartSummary is a data class, the new
+        // instance == the old instance (structural equality), so
+        // CartBanner skips recomposition since the cart content is unchanged.
         composeTestRule.onNodeWithTag("refresh_button").performClick()
 
-        // ISSUE: CartBanner recomposes despite no logical change to the cart
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 1)
-
-        // FIX: If CartSummary were a `data class`, equals() would compare
-        // fields structurally. CartSummary(0, "$0.0") == CartSummary(0, "$0.0")
-        // would be true, and Compose would SKIP the recomposition.
-        // The fixed assertion would be: assertFirstComposition()
+        // CartBanner stays stable despite unrelated parent recomposition
+        composeTestRule.onNodeWithTag("cart_banner").assertStable()
     }
 
     // ============================================================
@@ -159,15 +154,10 @@ class RecompositionRegressionTest {
             composeTestRule.onNodeWithTag("refresh_button").performClick()
         }
 
-        // CURRENT BEHAVIOR (issue): CartBanner recomposes on EVERY parent
-        // recomposition because CartSummary is unstable. That's 5 total
-        // recompositions (2 from selects + 3 from refreshes).
-        // Budget: at most 5 -- bounded at 1:1 with parent recompositions.
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atMost = 5)
-
-        // FIX: With `data class CartSummary`, only the 2 select clicks
-        // would cause recomposition (the content actually changes).
-        // The fixed assertion would be: assertRecomposesExactly(2)
+        // FIXED BEHAVIOR: CartSummary is a data class, so CartBanner only
+        // recomposes when the content changes (the 2 selects). Refreshes
+        // are skipped because the structural equality check passes.
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================
@@ -197,11 +187,9 @@ class RecompositionRegressionTest {
         // Footer stays stable due to strong skipping mode memoizing the lambda
         composeTestRule.onNodeWithTag("product_footer").assertStable()
 
-        // ISSUE: CartBanner recomposes on ALL 3 interactions (2 selects + 1 refresh)
-        // because each parent recomposition creates a new CartSummary instance.
-        // FIX: With `data class CartSummary`, only the 2 selects would cause
-        // recomposition. The fixed assertion would be: assertRecomposesExactly(2)
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 3)
+        // FIXED BEHAVIOR: With `data class CartSummary`, only the 2 selects cause
+        // recomposition. The refresh is skipped because the cart content is unchanged.
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================


### PR DESCRIPTION
💡 **What**: Changed `CartSummary` from a standard `class` to a `data class` in `ProductList.kt` and updated relevant assertions in `RecompositionRegressionTest.kt`.
🎯 **Why**: In Jetpack Compose, passing a standard class instance as state causes identity-based equality checks. Every parent recomposition created a new instance, leading to unnecessary recompositions of the `CartBanner` child component even when data was logically unchanged.
📊 **Impact**: Prevents unnecessary recompositions of `CartBanner` on unrelated parent state changes (like refreshing the page). For example, mixed interactions (2 selects + 3 refreshes) now result in 2 recompositions instead of 5.
🔬 **Measurement**: Verify via `RecompositionRegressionTest.kt`, where the `cartBanner_recomposesOnUnrelatedRefresh` test now successfully asserts `assertStable()` instead of `atLeast(1)`, and `performanceBudget_cartBannerOnMixedInteractions` requires `exactly(2)` instead of `atMost(5)`.

---
*PR created automatically by Jules for task [10363682896579662775](https://jules.google.com/task/10363682896579662775) started by @himattm*