### PR TITLE
⚡ Bolt: Optimize CartSummary recomposition

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Unstable Classes Cause Recompositions
+**Learning:** Regular classes (`class`) in Kotlin use identity-based equality (`Object.equals`). When used as Compose states or parameters, this means new instances always trigger a recomposition, even if the data inside hasn't changed. `CartSummary` was a regular class, so `CartBanner` unnecessarily recomposed every time `ProductListScreen` refreshed.
+**Action:** Always use `data class` for state objects passed as parameters to ensure structural equality and prevent unnecessary recompositions. Verify test logic with valid assertions (e.g., `assertStable()` vs `assertFirstComposition()`).

--- a/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
+++ b/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.unit.dp
 // ISSUE: Unstable class — uses identity-based equality (Object.equals),
 // causing recomposition even when the logical content is the same.
 // Making this a `data class` would fix the problem.
-class CartSummary(val itemCount: Int, val totalPrice: String)
+data class CartSummary(val itemCount: Int, val totalPrice: String)
 
 @Composable
 fun ProductListScreen() {

--- a/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
+++ b/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
@@ -116,12 +116,11 @@ class RecompositionRegressionTest {
         composeTestRule.onNodeWithTag("refresh_button").performClick()
 
         // ISSUE: CartBanner recomposes despite no logical change to the cart
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 1)
-
         // FIX: If CartSummary were a `data class`, equals() would compare
         // fields structurally. CartSummary(0, "$0.0") == CartSummary(0, "$0.0")
         // would be true, and Compose would SKIP the recomposition.
         // The fixed assertion would be: assertFirstComposition()
+        composeTestRule.onNodeWithTag("cart_banner").assertStable()
     }
 
     // ============================================================
@@ -163,11 +162,10 @@ class RecompositionRegressionTest {
         // recomposition because CartSummary is unstable. That's 5 total
         // recompositions (2 from selects + 3 from refreshes).
         // Budget: at most 5 -- bounded at 1:1 with parent recompositions.
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atMost = 5)
-
         // FIX: With `data class CartSummary`, only the 2 select clicks
         // would cause recomposition (the content actually changes).
         // The fixed assertion would be: assertRecomposesExactly(2)
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================
@@ -201,7 +199,7 @@ class RecompositionRegressionTest {
         // because each parent recomposition creates a new CartSummary instance.
         // FIX: With `data class CartSummary`, only the 2 selects would cause
         // recomposition. The fixed assertion would be: assertRecomposesExactly(2)
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 3)
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================


### PR DESCRIPTION
💡 **What:** Changed `CartSummary` from a regular `class` to a `data class` in `ProductList.kt` and updated assertions in `RecompositionRegressionTest.kt`.
🎯 **Why:** Regular Kotlin classes use identity equality. Because `CartSummary` is recreated on every parent recomposition, it passed a "new" instance to `CartBanner`, causing `CartBanner` to needlessly recompose even when the cart data (item count and total) was unchanged.
📊 **Impact:** Reduces `CartBanner` recompositions. It now skips recomposing on unrelated parent refreshes.
🔬 **Measurement:** The updated `RecompositionRegressionTest.kt` passes with `cartBanner` verifying `assertStable()` on unrelated interactions.

---
*PR created automatically by Jules for task [1726547632488120419](https://jules.google.com/task/1726547632488120419) started by @himattm*