### PR TITLE
⚡ Bolt: Use data class for CartSummary to prevent recompositions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2024-05-02 - Unstable Compose State
+
+**Learning:** Using a regular `class` instead of a `data class` for state passed to a Jetpack Compose component breaks Compose's structural equality checks (using reference equality instead). This causes unnecessary recompositions whenever the parent recomposes.
+
+**Action:** Always use `data class` for models passed as Jetpack Compose state parameters to enable structural equality checking and proper recomposition skipping.

--- a/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
+++ b/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.unit.dp
 // ISSUE: Unstable class — uses identity-based equality (Object.equals),
 // causing recomposition even when the logical content is the same.
 // Making this a `data class` would fix the problem.
-class CartSummary(val itemCount: Int, val totalPrice: String)
+data class CartSummary(val itemCount: Int, val totalPrice: String)
 
 @Composable
 fun ProductListScreen() {

--- a/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
+++ b/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
@@ -116,7 +116,7 @@ class RecompositionRegressionTest {
         composeTestRule.onNodeWithTag("refresh_button").performClick()
 
         // ISSUE: CartBanner recomposes despite no logical change to the cart
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 1)
+        composeTestRule.onNodeWithTag("cart_banner").assertStable()
 
         // FIX: If CartSummary were a `data class`, equals() would compare
         // fields structurally. CartSummary(0, "$0.0") == CartSummary(0, "$0.0")
@@ -163,7 +163,7 @@ class RecompositionRegressionTest {
         // recomposition because CartSummary is unstable. That's 5 total
         // recompositions (2 from selects + 3 from refreshes).
         // Budget: at most 5 -- bounded at 1:1 with parent recompositions.
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atMost = 5)
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
 
         // FIX: With `data class CartSummary`, only the 2 select clicks
         // would cause recomposition (the content actually changes).
@@ -201,7 +201,7 @@ class RecompositionRegressionTest {
         // because each parent recomposition creates a new CartSummary instance.
         // FIX: With `data class CartSummary`, only the 2 selects would cause
         // recomposition. The fixed assertion would be: assertRecomposesExactly(2)
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 3)
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================


### PR DESCRIPTION
### 💡 What
Changed `CartSummary` from a regular `class` to a `data class` in `demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt`.

### 🎯 Why
When `CartSummary` was a regular `class`, Compose used reference equality to determine if the parameter had changed. This meant that every time the parent `ProductListScreen` recomposed, a new `CartSummary` instance was created, and `CartBanner` would unnecessarily recompose even if the cart content remained identical. By switching to a `data class`, Compose uses structural equality (comparing the actual `itemCount` and `totalPrice` properties), correctly skipping recompositions when the contents have not changed.

### 📊 Impact
Prevents unnecessary recompositions of the `CartBanner` component on unrelated state changes (like refreshing). In the mixed interaction test, recomposition counts were reduced from 5 to 2.

### 🔬 Measurement
Run `./gradlew test` and verify that the updated tests in `demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt` (which expect a `assertStable()` and exactly 2 recompositions instead of the previous higher bounds) pass cleanly.

---
*PR created automatically by Jules for task [5882054204480952581](https://jules.google.com/task/5882054204480952581) started by @himattm*