### PR TITLE
⚡ Bolt: [performance improvement] Change CartSummary to a data class to prevent unnecessary recompositions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - [Compose Stability]
+**Learning:** Passing a regular class as a parameter in Compose causes unnecessary recompositions because Compose uses `Object.equals` (identity-based) for non-data classes, while `data class` enables structural equality and skipping.
+**Action:** Always use `data class` for state objects passed as parameters to ensure structural equality and prevent unnecessary recompositions.

--- a/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
+++ b/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.unit.dp
 // ISSUE: Unstable class — uses identity-based equality (Object.equals),
 // causing recomposition even when the logical content is the same.
 // Making this a `data class` would fix the problem.
-class CartSummary(val itemCount: Int, val totalPrice: String)
+data class CartSummary(val itemCount: Int, val totalPrice: String)
 
 @Composable
 fun ProductListScreen() {

--- a/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
+++ b/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
@@ -116,7 +116,7 @@ class RecompositionRegressionTest {
         composeTestRule.onNodeWithTag("refresh_button").performClick()
 
         // ISSUE: CartBanner recomposes despite no logical change to the cart
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 1)
+        composeTestRule.onNodeWithTag("cart_banner").assertStable()
 
         // FIX: If CartSummary were a `data class`, equals() would compare
         // fields structurally. CartSummary(0, "$0.0") == CartSummary(0, "$0.0")
@@ -163,7 +163,7 @@ class RecompositionRegressionTest {
         // recomposition because CartSummary is unstable. That's 5 total
         // recompositions (2 from selects + 3 from refreshes).
         // Budget: at most 5 -- bounded at 1:1 with parent recompositions.
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atMost = 5)
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
 
         // FIX: With `data class CartSummary`, only the 2 select clicks
         // would cause recomposition (the content actually changes).
@@ -201,7 +201,7 @@ class RecompositionRegressionTest {
         // because each parent recomposition creates a new CartSummary instance.
         // FIX: With `data class CartSummary`, only the 2 selects would cause
         // recomposition. The fixed assertion would be: assertRecomposesExactly(2)
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 3)
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================


### PR DESCRIPTION
💡 What: Changed `CartSummary` from a regular class to a `data class` in `ProductList.kt` and updated the related assertions in `RecompositionRegressionTest.kt`.
🎯 Why: A regular class uses identity-based equality (`Object.equals`), meaning each parent recomposition creates a new instance that forces `CartBanner` to recompose, even when logical values (e.g., total price and item count) are exactly the same. Making it a `data class` allows Compose to use structural equality and skip recomposition.
📊 Impact: Reduces unneeded `CartBanner` recompositions. It drops interactions that don't logically update the cart from `atLeast = 1` unneeded recompositions down to `0` (Stable). In mixed tests, recompositions dropped from 5 to 2.
🔬 Measurement: Verify by running `RecompositionRegressionTest.kt` assertions which now enforce stability (`assertStable()`) when only unrelated content changes.

---
*PR created automatically by Jules for task [13876448279272267603](https://jules.google.com/task/13876448279272267603) started by @himattm*