### PR TITLE
⚡ Bolt: Make CartSummary a data class to prevent unnecessary recompositions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Use data classes for Compose parameters
+**Learning:** Classes passed to Compose functions should be data classes so that Jetpack Compose compares them structurally via equals(). Otherwise, identity equality causes unnecessary recompositions when the parent recomposes.
+**Action:** Always use data classes for objects holding view state passed as composable parameters.

--- a/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
+++ b/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.unit.dp
 // ISSUE: Unstable class — uses identity-based equality (Object.equals),
 // causing recomposition even when the logical content is the same.
 // Making this a `data class` would fix the problem.
-class CartSummary(val itemCount: Int, val totalPrice: String)
+data class CartSummary(val itemCount: Int, val totalPrice: String)
 
 @Composable
 fun ProductListScreen() {

--- a/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
+++ b/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
@@ -116,7 +116,7 @@ class RecompositionRegressionTest {
         composeTestRule.onNodeWithTag("refresh_button").performClick()
 
         // ISSUE: CartBanner recomposes despite no logical change to the cart
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 1)
+        composeTestRule.onNodeWithTag("cart_banner").assertStable()
 
         // FIX: If CartSummary were a `data class`, equals() would compare
         // fields structurally. CartSummary(0, "$0.0") == CartSummary(0, "$0.0")
@@ -163,7 +163,7 @@ class RecompositionRegressionTest {
         // recomposition because CartSummary is unstable. That's 5 total
         // recompositions (2 from selects + 3 from refreshes).
         // Budget: at most 5 -- bounded at 1:1 with parent recompositions.
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atMost = 5)
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
 
         // FIX: With `data class CartSummary`, only the 2 select clicks
         // would cause recomposition (the content actually changes).
@@ -201,7 +201,7 @@ class RecompositionRegressionTest {
         // because each parent recomposition creates a new CartSummary instance.
         // FIX: With `data class CartSummary`, only the 2 selects would cause
         // recomposition. The fixed assertion would be: assertRecomposesExactly(2)
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 3)
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================


### PR DESCRIPTION
💡 **What:** Changed `CartSummary` from a regular `class` to a `data class`.

🎯 **Why:** Regular classes in Kotlin are compared by reference. When `ProductListScreen` recomposed (e.g. from an unrelated refresh count change), a new `CartSummary` instance was created. Compose saw a new reference and unnecessarily recomposed `CartBanner`, even when the cart items and total price were identical. By making it a `data class`, Compose can compare the contents structurally.

📊 **Impact:** Reduces `CartBanner` recompositions. Wasted recompositions on unrelated parent state changes (like refreshing) drop to 0, bounding recompositions tightly to 1:1 with actual cart content updates.

🔬 **Measurement:** `demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt` was updated to assert the fixed expected behavior (`assertStable()` instead of `atLeast = 1` for refresh actions, exactly 2 instead of at least 3 for combined operations).

---
*PR created automatically by Jules for task [1562027274511002186](https://jules.google.com/task/1562027274511002186) started by @himattm*