### PR TITLE
test: strengthen runTest rule setup regression

### DIFF
--- a/demo/src/androidTest/java/demo/app/RunTestRuleSetupTest.kt
+++ b/demo/src/androidTest/java/demo/app/RunTestRuleSetupTest.kt
@@ -2,20 +2,20 @@ package demo.app
 
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import dejavu.Dejavu
 import dejavu.assertStable
 import dejavu.createRecompositionTrackingRule
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.Description
 import org.junit.runner.RunWith
+import org.junit.runners.model.Statement
 
 /**
- * Regression test for issue #80: `DejavuComposeTestRule.apply()` must work when the
- * test body is wrapped in `kotlinx.coroutines.test.runTest`.
- *
- * Without the fix in `DejavuComposeTestRule`, setup runs on a `TestDispatcher` thread
- * (no `Looper`) and crashes with `IllegalStateException: The current thread must
- * have a looper!` from `Choreographer.getInstance()`.
+ * Regression tests for issue #80: `DejavuComposeTestRule.apply()` must work when
+ * rule setup runs inside compose-ui-test's coroutine test scope.
  */
 @RunWith(AndroidJUnit4::class)
 class RunTestRuleSetupTest {
@@ -26,5 +26,33 @@ class RunTestRuleSetupTest {
     @Test
     fun ruleSetup_succeedsInsideRunTest() = runTest {
         composeTestRule.onNodeWithTag("counter_value").assertStable()
+    }
+
+    @Test
+    fun ruleSetup_succeedsWhenDejavuWasNotPreEnabledByTheApp() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            Dejavu.disable()
+        }
+
+        val rule = createRecompositionTrackingRule<CounterActivity>()
+        val statement = rule.apply(
+            object : Statement() {
+                override fun evaluate() {
+                    rule.onNodeWithTag("counter_value").assertStable()
+                }
+            },
+            Description.createTestDescription(
+                RunTestRuleSetupTest::class.java,
+                "ruleSetup_succeedsWhenDejavuWasNotPreEnabledByTheApp",
+            ),
+        )
+
+        try {
+            statement.evaluate()
+        } finally {
+            InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                Dejavu.disable()
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Strengthens the issue #80 regression coverage for `DejavuComposeTestRule` setup under compose-ui-test's coroutine test scope.

The existing regression test passed, but it did not actually prove the fix: the demo app's debug `Application` pre-enables Dejavu on the main thread, which masks the failing path. This adds a focused test that disables Dejavu first, manually applies a fresh `createRecompositionTrackingRule<CounterActivity>()`, and then evaluates the rule. That reproduces the real user scenario where Dejavu is not already enabled by the host app.

## Root cause of the weak test

- `demo/src/debug/java/demo/app/App.kt` calls `Dejavu.enable(...)` from `Application.onCreate()` on the main thread.
- Because Dejavu was already enabled, temporarily reverting the rule setup fix could still pass locally.
- When the test explicitly starts from `Dejavu.disable()`, the old direct `Runtime.seedActiveActivity(...)` call runs inside compose-ui-test's `runTest` dispatcher thread and fails with `IllegalStateException: The current thread must have a looper!`.

## Verification

RED check, with the `DejavuComposeTestRule` fix temporarily reverted:

```text
./gradlew --console=plain :demo:connectedDebugAndroidTest \
  -Pandroid.testInstrumentationRunnerArguments.class=demo.app.RunTestRuleSetupTest#ruleSetup_succeedsWhenDejavuWasNotPreEnabledByTheApp \
  -PcomposeBomVersion=2026.04.01 -PexcludeCompositionObserver=false --rerun-tasks
```

Result: failed as expected:

```text
java.lang.IllegalStateException: The current thread must have a looper!
at android.view.Choreographer.getInstance(...)
at dejavu.internal.Runtime.seedActiveActivity$dejavu_debug(Runtime.kt:236)
at dejavu.DejavuComposeTestRule$apply$1.evaluate(DejavuComposeTestRule.kt:29)
at androidx.compose.ui.test.junit4.AndroidComposeTestRule$apply$testWithDisposal$1.evaluate(AndroidComposeTestRule.android.kt:418)
at androidx.compose.ui.test.AndroidComposeUiTestEnvironment.runTest(ComposeUiTest.android.kt:658)
```

GREEN check, with current main's fix restored:

```text
./gradlew -q --console=plain :demo:connectedDebugAndroidTest \
  -Pandroid.testInstrumentationRunnerArguments.class=demo.app.RunTestRuleSetupTest \
  -PcomposeBomVersion=2026.04.01 -PexcludeCompositionObserver=false --rerun-tasks
```

Result: passed.

## Notes

No production code changes here; the existing main-thread setup fix is still the right behavior. This PR makes the regression test actually fail without that fix.
