### PR TITLE
⚡ Bolt: [performance improvement] Convert CartSummary to data class to prevent needless recompositions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Jetpack Compose Stability with Data Classes
+**Learning:** Regular Kotlin classes use identity-based equality, causing Compose to falsely detect changes when instances are recreated with identical data, triggering needless recompositions. Using `data class` enables structural equality which fixes this issue.
+**Action:** Always use `data class` for objects passed into Jetpack Compose UI parameters unless identity equality is intentionally required.

--- a/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
+++ b/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
@@ -43,10 +43,10 @@ import androidx.compose.ui.unit.dp
 // FIX: Make CartSummary a data class so equals() is structural.
 // ============================================================
 
-// ISSUE: Unstable class — uses identity-based equality (Object.equals),
+// FIXED: Unstable class — previously used identity-based equality (Object.equals),
 // causing recomposition even when the logical content is the same.
-// Making this a `data class` would fix the problem.
-class CartSummary(val itemCount: Int, val totalPrice: String)
+// Made this a `data class` to fix the problem by ensuring structural equality.
+data class CartSummary(val itemCount: Int, val totalPrice: String)
 
 @Composable
 fun ProductListScreen() {

--- a/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
+++ b/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
@@ -116,12 +116,11 @@ class RecompositionRegressionTest {
         composeTestRule.onNodeWithTag("refresh_button").performClick()
 
         // ISSUE: CartBanner recomposes despite no logical change to the cart
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 1)
-
         // FIX: If CartSummary were a `data class`, equals() would compare
         // fields structurally. CartSummary(0, "$0.0") == CartSummary(0, "$0.0")
         // would be true, and Compose would SKIP the recomposition.
-        // The fixed assertion would be: assertFirstComposition()
+        // The fixed assertion would be: assertStable()
+        composeTestRule.onNodeWithTag("cart_banner").assertStable()
     }
 
     // ============================================================
@@ -163,11 +162,10 @@ class RecompositionRegressionTest {
         // recomposition because CartSummary is unstable. That's 5 total
         // recompositions (2 from selects + 3 from refreshes).
         // Budget: at most 5 -- bounded at 1:1 with parent recompositions.
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atMost = 5)
-
         // FIX: With `data class CartSummary`, only the 2 select clicks
         // would cause recomposition (the content actually changes).
-        // The fixed assertion would be: assertRecomposesExactly(2)
+        // The fixed assertion would be: assertRecompositions(exactly = 2)
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================
@@ -200,8 +198,8 @@ class RecompositionRegressionTest {
         // ISSUE: CartBanner recomposes on ALL 3 interactions (2 selects + 1 refresh)
         // because each parent recomposition creates a new CartSummary instance.
         // FIX: With `data class CartSummary`, only the 2 selects would cause
-        // recomposition. The fixed assertion would be: assertRecomposesExactly(2)
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 3)
+        // recomposition. The fixed assertion would be: assertRecompositions(exactly = 2)
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================


### PR DESCRIPTION
💡 What: Converted `class CartSummary` to `data class CartSummary` in `demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt`.
🎯 Why: Regular classes use identity-based referential equality. Because the parent `ProductListScreen` created a new `CartSummary` instance on every recomposition, Compose saw this as a "changed" parameter and needlessly recomposed `CartBanner`, even if the underlying `itemCount` and `totalPrice` had not changed. `data class` enables structural equality (`equals()` compares fields), so Compose can safely skip recomposition.
📊 Impact: Eliminates needless recompositions of the `CartBanner` component, reducing UI render cycles when unrelated parts of the screen update (like the refresh button).
🔬 Measurement: Run the Dejavu recomposition verification tests (`./gradlew testDebugUnitTest`) and observe that `CartBanner` now correctly skips recomposition.

---
*PR created automatically by Jules for task [15901048929773682013](https://jules.google.com/task/15901048929773682013) started by @himattm*