### PR TITLE
⚡ Bolt: [performance improvement] Optimize CartSummary by using a data class

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Making State Objects Data Classes for Structural Equality
+**Learning:** In Compose, regular classes passed as parameters cause recomposition when the parent recomposes, because their reference changes even if the content is functionally the same (due to identity-based equality via `Object.equals`).
+**Action:** Use `data class` for state objects passed as parameters to ensure structural equality (`equals()`), preventing unnecessary recompositions.

--- a/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
+++ b/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.unit.dp
 // ISSUE: Unstable class — uses identity-based equality (Object.equals),
 // causing recomposition even when the logical content is the same.
 // Making this a `data class` would fix the problem.
-class CartSummary(val itemCount: Int, val totalPrice: String)
+data class CartSummary(val itemCount: Int, val totalPrice: String)
 
 @Composable
 fun ProductListScreen() {

--- a/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
+++ b/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
@@ -108,20 +108,14 @@ class RecompositionRegressionTest {
 
     @Test
     fun cartBanner_recomposesOnUnrelatedRefresh() {
-        // CURRENT BEHAVIOR (issue): Clicking refresh changes refreshCount,
-        // which recomposes ProductListScreen. A new CartSummary(0, "$0.0")
-        // is created. Because CartSummary is NOT a data class, the new
-        // instance != the old instance (reference inequality), so
-        // CartBanner recomposes even though the cart content is unchanged.
+        // Clicking refresh changes refreshCount, which recomposes ProductListScreen.
+        // A new CartSummary(0, "$0.0") is created. Since CartSummary is a data class,
+        // the new instance == the old instance (structural equality), so Compose skips
+        // recomposing CartBanner.
         composeTestRule.onNodeWithTag("refresh_button").performClick()
 
-        // ISSUE: CartBanner recomposes despite no logical change to the cart
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 1)
-
-        // FIX: If CartSummary were a `data class`, equals() would compare
-        // fields structurally. CartSummary(0, "$0.0") == CartSummary(0, "$0.0")
-        // would be true, and Compose would SKIP the recomposition.
-        // The fixed assertion would be: assertFirstComposition()
+        // CartBanner stays stable due to CartSummary being a data class
+        composeTestRule.onNodeWithTag("cart_banner").assertStable()
     }
 
     // ============================================================
@@ -159,15 +153,10 @@ class RecompositionRegressionTest {
             composeTestRule.onNodeWithTag("refresh_button").performClick()
         }
 
-        // CURRENT BEHAVIOR (issue): CartBanner recomposes on EVERY parent
-        // recomposition because CartSummary is unstable. That's 5 total
-        // recompositions (2 from selects + 3 from refreshes).
-        // Budget: at most 5 -- bounded at 1:1 with parent recompositions.
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atMost = 5)
-
-        // FIX: With `data class CartSummary`, only the 2 select clicks
-        // would cause recomposition (the content actually changes).
-        // The fixed assertion would be: assertRecomposesExactly(2)
+        // With `data class CartSummary`, only the 2 select clicks
+        // cause recomposition (the content actually changes).
+        // Refresh clicks are skipped.
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================
@@ -197,11 +186,9 @@ class RecompositionRegressionTest {
         // Footer stays stable due to strong skipping mode memoizing the lambda
         composeTestRule.onNodeWithTag("product_footer").assertStable()
 
-        // ISSUE: CartBanner recomposes on ALL 3 interactions (2 selects + 1 refresh)
-        // because each parent recomposition creates a new CartSummary instance.
-        // FIX: With `data class CartSummary`, only the 2 selects would cause
-        // recomposition. The fixed assertion would be: assertRecomposesExactly(2)
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 3)
+        // With `data class CartSummary`, only the 2 selects cause recomposition.
+        // The refresh is skipped because the cart content structurally equals.
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================


### PR DESCRIPTION
💡 **What**: Changed `CartSummary` from a regular `class` to a `data class` in `ProductList.kt` and updated assertions in `RecompositionRegressionTest.kt` to enforce the new behavior.
🎯 **Why**: In Jetpack Compose, passing a regular class as a state parameter triggers unnecessary recompositions because it uses identity-based equality (`Object.equals`). When a parent component recomposes, a new class instance is created and triggers recomposition of the child. `data class` uses structural equality, allowing Compose to skip recomposition when the logical content remains the same.
📊 **Impact**: This reduces the number of unnecessary recompositions of the `CartBanner` component caused by unrelated parent state updates (e.g. refreshes) by 100%. The test updates reflect the improved recomposition counts.
🔬 **Measurement**: Run the instrumented tests for the app using `./gradlew :demo:compileDebugAndroidTestKotlin` locally and verify the assertions on `cart_banner` in `demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt`.

---
*PR created automatically by Jules for task [9554353164317662351](https://jules.google.com/task/9554353164317662351) started by @himattm*