### PR TITLE
Batch dependency bumps: Kotlin 2.4.0, coroutines 1.11.0, atomicfu 0.33.0, lifecycle 2.11.0, core-ktx 1.19.0, maven-publish 0.37.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,21 +1,21 @@
 [versions]
 agp = "9.1.0"
-kotlin = "2.3.20"
-coreKtx = "1.18.0"
+kotlin = "2.4.0"
+coreKtx = "1.19.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
-lifecycleRuntimeKtx = "2.9.2"
+lifecycleRuntimeKtx = "2.11.0"
 activityCompose = "1.13.0"
 composeBom = "2026.03.01"
 composeMultiplatform = "1.10.3"
-coroutinesAndroid = "1.9.0"
-atomicfu = "0.32.1"
+coroutinesAndroid = "1.11.0"
+atomicfu = "0.33.0"
 binary-compatibility-validator = "0.17.0"
 dokka = "2.2.0"
 robolectric = "4.16.1"
 truth = "1.4.4"
-vanniktech-maven-publish = "0.36.0"
+vanniktech-maven-publish = "0.37.0"
 
 [libraries]
 kotlinx-atomicfu = { group = "org.jetbrains.kotlinx", name = "atomicfu", version.ref = "atomicfu" }


### PR DESCRIPTION
Supersedes #109 #107 #103 #99 #91 #102

Validated locally: jvmTest, testDebugUnitTest, wasmJsBrowserTest, iosSimulatorArm64Test, apiCheck, connectedDebugAndroidTest
