### PR TITLE
Bump mkdocs deps: mike 2.2.0, pymdown-extensions 10.21.3

### DIFF
--- a/.github/workflows/mkdocs-requirements.txt
+++ b/.github/workflows/mkdocs-requirements.txt
@@ -1,6 +1,6 @@
 mkdocs==1.6.1
 mkdocs-material==9.7.6
 mkdocs-material-extensions==1.3.1
-mike==2.1.4
+mike==2.2.0
 Pygments==2.20.0
-pymdown-extensions==10.21
+pymdown-extensions==10.21.3


### PR DESCRIPTION
Supersedes #57 and #95 (dependabot branches conflicted with the Pygments bump on main). Docs-tooling only; no gradle impact.