### PR TITLE
Release DejaVu 0.5.0 for Compose 1.12

### DIFF
--- a/.claude/skills/dejavu-onboarding/SKILL.md
+++ b/.claude/skills/dejavu-onboarding/SKILL.md
@@ -55,7 +55,7 @@ For Android (single-platform):
 ```kotlin
 // app/build.gradle.kts
 dependencies {
-    androidTestImplementation("me.mmckenna.dejavu:dejavu:0.4.0")
+    androidTestImplementation("me.mmckenna.dejavu:dejavu:0.5.0")
 }
 ```
 
@@ -67,7 +67,7 @@ gradle DSL:
 kotlin {
     sourceSets {
         commonTest.dependencies {
-            implementation("me.mmckenna.dejavu:dejavu:0.4.0")
+            implementation("me.mmckenna.dejavu:dejavu:0.5.0")
         }
     }
 }
@@ -80,7 +80,7 @@ kotlin {
     sourceSets {
         val commonTest by getting {
             dependencies {
-                implementation("me.mmckenna.dejavu:dejavu:0.4.0")
+                implementation("me.mmckenna.dejavu:dejavu:0.5.0")
             }
         }
     }
@@ -88,7 +88,7 @@ kotlin {
 ```
 
 Use the latest version from Maven Central (the README badge has the current
-number) compatible with the project's Compose version. DejaVu 0.4.x requires Compose 1.11;
+number) compatible with the project's Compose version. DejaVu 0.5.x requires Compose 1.11;
 Compose 1.10 projects should stay on 0.3.1. Don't downgrade a compatible newer release.
 
 ### 4. Pick a target composable for the first test
@@ -200,7 +200,7 @@ Filter logcat with tag `Dejavu`. See `docs/use-cases.md` "Stream Composition Sta
   compiler plugin if it isn't already configured.
 - **Wasm test completion** — return `runRecompositionTrackingUiTest` directly from the test.
   Put diagnostic assertions inside its body so the runner awaits their asynchronous result.
-  DejaVu 0.4.0 restores lazy-grid and diagnostic-message coverage on iOS/Wasm.
+  DejaVu 0.5.0 restores lazy-grid and diagnostic-message coverage on iOS/Wasm.
 
 ## Wrap-up
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.0] - Unreleased
+## [0.5.0] - 2026-09-09
 
 ### Changed
 - Build against stable Compose Multiplatform 1.12.0 and Android BOM 2026.08.00 (Compose 1.12.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Retain Android BOM 2026.05.00 and 2026.06.01 as the minimum and latest 1.11 checkpoints.
   Retire the redundant intermediate 2026.06.00 checkpoint without moving the support floor.
 - Upgrade the build to AGP 9.4.0 and compile SDK 37 for the new Android Compose artifacts.
+  The published AAR requires consumers to use compile SDK 37. Retaining Android Compose 1.11
+  requires an enforced BOM so the transitive 1.12 baseline does not win resolution.
 - Adapt experimental Styles fixtures to the changed `pressed` API with separate 1.11 and 1.12
   test sources. Both retain the same deliberately inefficient and stable fixture behavior.
 - Declare Wasm executables for browser UI tests, as required by Compose Multiplatform 1.12's
@@ -31,6 +33,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Unkeyed `SideEffect` remains the independent recomposition-count oracle.
 - Version-specific tests compile only where the API exists. Older Android BOM checks retain the
   complete core suite and the original 20 experimental tests; 1.12 adds the six new regressions.
+- A standalone consumer build verifies packaged Maven artifacts across Android checkpoints and
+  the KMP baseline. Release checks now reject empty, failing, or skipped JUnit reports.
+
+### Fixed
+- Combine Android activity inspection tables with tables supplied by `setTrackedContent`.
+  Previously, enabling the Android tracking rule before a KMP helper test in the same process
+  could hide the helper's subcomposition and report an unmapped tag. A dedicated Android
+  regression and the packaged consumer suite cover both harnesses together.
+- Restore previously active tracing and inspector settings after the KMP helper finishes, so
+  a subsequent Android rule keeps tracking. The regression checks the full rule/helper/rule path.
+- Enable Android tracking before activity launch so initial inspection tables are registered
+  after a previous test disabled tracking. The setup regression verifies the first update against
+  an independent `SideEffect` count.
 
 ## [0.4.0] - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - Unreleased
+
+### Changed
+- Build against stable Compose Multiplatform 1.12.0 and Android BOM 2026.08.00 (Compose 1.12.0).
+  DejaVu keeps independent version numbers and the Android Compose 1.11 support floor.
+- Retain Android BOM 2026.05.00 and 2026.06.01 as the minimum and latest 1.11 checkpoints.
+  Retire the redundant intermediate 2026.06.00 checkpoint without moving the support floor.
+- Upgrade the build to AGP 9.4.0 and compile SDK 37 for the new Android Compose artifacts.
+- Adapt experimental Styles fixtures to the changed `pressed` API with separate 1.11 and 1.12
+  test sources. Both retain the same deliberately inefficient and stable fixture behavior.
+- Declare Wasm executables for browser UI tests, as required by Compose Multiplatform 1.12's
+  Skiko bundling check. The library continues to publish Wasm KLIB artifacts.
+
+### Added
+- The Android rule delegates Compose 1.12's `hasPendingWork` and `runWithoutImplicitWait` APIs.
+  These new methods require Compose 1.12; existing rule methods remain covered on Compose 1.11.
+- Six public-API regressions for Compose 1.12: stable and changed keyed `SideEffect`, shrinking
+  vararg effect keys, shrinking `remember` keys, frame assertions using `runWithoutImplicitWait`,
+  and nested movable content under the LinkBuffer composer.
+- The keyed-effect regression deliberately recomposes four times while the keyed callback stays
+  quiet, proving DejaVu counts every recomposition and rejects an incorrect stability budget.
+  Unkeyed `SideEffect` remains the independent recomposition-count oracle.
+- Version-specific tests compile only where the API exists. Older Android BOM checks retain the
+  complete core suite and the original 20 experimental tests; 1.12 adds the six new regressions.
+
 ## [0.4.0] - 2026-09-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![CI](https://github.com/himattm/dejavu/actions/workflows/ci.yml/badge.svg)](https://github.com/himattm/dejavu/actions/workflows/ci.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/me.mmckenna.dejavu/dejavu)](https://central.sonatype.com/artifact/me.mmckenna.dejavu/dejavu)
-[![Compose](https://img.shields.io/badge/Compose-1.11.x-4285F4?logo=jetpackcompose&logoColor=white)](https://developer.android.com/develop/ui/compose)
+[![Compose](https://img.shields.io/badge/Compose-1.11–1.12-4285F4?logo=jetpackcompose&logoColor=white)](https://developer.android.com/develop/ui/compose)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ###### Featured In
@@ -44,7 +44,7 @@ Dejavu is a test-only library that turns recomposition behavior into assertions.
 ```kotlin
 // app/build.gradle.kts
 dependencies {
-    androidTestImplementation("me.mmckenna.dejavu:dejavu:0.4.0")
+    androidTestImplementation("me.mmckenna.dejavu:dejavu:0.5.0")
 }
 ```
 
@@ -188,18 +188,18 @@ All tracking runs in the app process on the main thread, directly accessible to 
 
 ## Compatibility
 
-Supported Compose range for Dejavu 0.4.x: **1.11.x (BOM 2026.05.00 through 2026.06.01)**.
+Supported Compose range for Dejavu 0.5.x: **1.11.x–1.12.x (BOM 2026.05.00 through 2026.08.00)**.
 
-**Minimum supported Compose: 1.11 (BOM 2026.05.00).** Dejavu 0.4.x uses the Compose testing v2 APIs introduced with this line. For Compose 1.10, use Dejavu 0.3.1; that maintenance release preserves the older Compose line instead of allowing newer transitive artifacts to mask an unsupported combination. Validated with Kotlin 2.4.0 and its Compose compiler plugin.
+**Minimum supported Compose: 1.11 (BOM 2026.05.00).** Dejavu 0.5.x uses the Compose testing v2 APIs introduced with this line. For Compose 1.10, use Dejavu 0.3.1; that maintenance release preserves the older Compose line instead of allowing newer transitive artifacts to mask an unsupported combination. Validated with Kotlin 2.4.0 and its Compose compiler plugin.
 
-Dejavu 0.4.x is built and released against **Compose Multiplatform 1.11.1**. Android consumers
+Dejavu 0.5.x is built and released against **Compose Multiplatform 1.12.0**. Android consumers
 can use any validated BOM in the support window; they do not have to match the release BOM exactly.
 
-| Compose BOM | Compose | Kotlin | Status |
+| Compose BOM | Compose | Kotlin tested | Status |
 |---|---|---|---|
-| 2026.05.00 | 1.11.x | 2.3.x+ | Minimum |
-| 2026.06.00 | 1.11.x | 2.3.x+ | Previous 1.11 checkpoint |
-| 2026.06.01 | 1.11.x | 2.3.x+ | Release baseline |
+| 2026.05.00 | 1.11.x | 2.4.0 | Minimum |
+| 2026.06.01 | 1.11.x | 2.4.0 | Latest 1.11 checkpoint |
+| 2026.08.00 | 1.12.x | 2.4.0 | Release baseline |
 
 ## Kotlin Multiplatform
 
@@ -210,7 +210,7 @@ Dejavu supports Kotlin Multiplatform with the following targets:
 | Android | Full support | Tag mapping via `ui-tooling-data` Group tree |
 | Desktop (JVM) | Full support | Tag mapping via `CompositionGroup` + `sourceInfo` |
 | iOS (arm64, simulatorArm64) | Supported | Same as JVM; Compose Multiplatform 1.11 no longer supports `iosX64` |
-| WasmJs (browser) | Supported | Exception propagation limited in test runner |
+| WasmJs (browser) | Supported | Async result and diagnostic-message regressions verified |
 
 ### KMP Test Setup
 
@@ -231,18 +231,29 @@ can suspend; Dejavu keeps tracking enabled until the body finishes and then clea
 It handles all Dejavu lifecycle management automatically -- enabling the tracer and resetting state. `setTrackedContent` wraps `setContent` with the inspection tables
 and sub-composition layout required for tag-to-function mapping.
 
-### Compose 1.11 Coverage
+### New Compose API Coverage
 
 Dejavu is validated against Compose 1.11's new composables and runtime paths via the
 `compose-experimental` module — a staging area for recomposition coverage of experimental /
 newest-Compose APIs before they graduate into the core accuracy suite. It exercises recomposition
-tracking on JVM, iOS, Wasm, and Android instrumented; Android runs every supported 1.11 BOM for:
+tracking on JVM, iOS, Wasm, and Android instrumented; Android runs every supported BOM for:
 
 - the experimental non-lazy `Grid` and `FlexBox` layouts,
 - `derivedMediaQuery` / `mediaQuery` adaptive breakpoints,
 - the Styles API (`androidx.compose.foundation.style`),
 - `movableContentOf`, and
 - the experimental LinkBuffer composer runtime path (`ComposeRuntimeFlags.isLinkBufferComposerEnabled`).
+
+### Compose 1.12 Coverage
+
+The Compose 1.12 baseline additionally validates keyed `SideEffect`, shrinking vararg effect and
+`remember` keys, assertions using `runWithoutImplicitWait`, and nested movable content under
+LinkBuffer. Exact counters continue using unkeyed `SideEffect`, including a deliberately inefficient
+fixture whose keyed callback stays quiet during four recompositions. The experimental suite runs
+26 tests on 1.12 and retains 20 on the supported Android 1.11 checkpoints.
+
+`DejavuComposeTestRule` delegates the new `hasPendingWork` and `runWithoutImplicitWait` methods on
+Compose 1.12. These methods require 1.12; the existing rule API remains covered on Android 1.11.
 
 ## Known Limitations
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,16 @@ Supported Compose range for Dejavu 0.5.x: **1.11.x–1.12.x (BOM 2026.05.00 thro
 **Minimum supported Compose: 1.11 (BOM 2026.05.00).** Dejavu 0.5.x uses the Compose testing v2 APIs introduced with this line. For Compose 1.10, use Dejavu 0.3.1; that maintenance release preserves the older Compose line instead of allowing newer transitive artifacts to mask an unsupported combination. Validated with Kotlin 2.4.0 and its Compose compiler plugin.
 
 Dejavu 0.5.x is built and released against **Compose Multiplatform 1.12.0**. Android consumers
-can use any validated BOM in the support window; they do not have to match the release BOM exactly.
+use the release BOM by default. To keep an older validated Android Compose line, enforce that
+BOM in both app and instrumentation-test dependencies; otherwise Gradle may select DejaVu's newer
+transitive baseline. Android consumers of 0.5.0 must use **compile SDK 37**, as declared in the AAR
+metadata. Use DejaVu 0.4.0 for the Compose Multiplatform 1.11 / compile SDK 36 release baseline.
+
+```kotlin
+val composeBom = enforcedPlatform("androidx.compose:compose-bom:2026.06.01")
+implementation(composeBom)
+androidTestImplementation(composeBom)
+```
 
 | Compose BOM | Compose | Kotlin tested | Status |
 |---|---|---|---|

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -43,7 +43,11 @@ behavior across those releases.
    a new run. Document any difference between the local device coverage and the hosted CI matrix.
    Equivalent passing local checks are sufficient if hosted CI is unavailable or fails because of
    budget or infrastructure. Reproduced product failures must still be fixed.
-7. Commit the verified changes and tag the merge commit as `vX.Y.Z`. Publishing is an explicit
+7. Publish the candidate to Maven Local once using its release baseline, then run the
+   [standalone consumer checks](validation/consumer/README.md) against those same artifacts on
+   the retained Android BOMs and KMP baseline. Inspect AAR minimum compile SDK and resolved runtime
+   versions. This verifies the packaged binary without recompiling it for each older Compose BOM.
+8. Commit the verified changes and tag the merge commit as `vX.Y.Z`. Publishing is an explicit
    workflow dispatch so pushing a tag does not spend CI minutes repeating the full suite:
 
    ```bash
@@ -53,9 +57,9 @@ behavior across those releases.
 
    The workflow requires a tag matching the Gradle version, the full verified commit SHA, and
    the checked-in validation record. Omit `local_verification` to run the hosted test suite first.
-8. Verify that every target artifact is available from Maven Central, then create the GitHub
+9. Verify that every target artifact is available from Maven Central, then create the GitHub
    release from the matching changelog entry. Record the release URL and artifact availability in
    the [shared release tracker](https://docs.google.com/document/d/1nfIzsfxz0ze_rTy5EKO0vG8TO_JyXDdricco7q5oyfY/edit).
    Keep release notes and social post drafts there; social copy must describe only verified changes.
-9. Set the next development version to `X.Y.Z-SNAPSHOT` after publication, as in
+10. Set the next development version to `X.Y.Z-SNAPSHOT` after publication, as in
    [Coil's release checklist](https://github.com/coil-kt/coil/blob/main/RELEASING.md).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -61,5 +61,12 @@ behavior across those releases.
    release from the matching changelog entry. Record the release URL and artifact availability in
    the [shared release tracker](https://docs.google.com/document/d/1nfIzsfxz0ze_rTy5EKO0vG8TO_JyXDdricco7q5oyfY/edit).
    Keep release notes and social post drafts there; social copy must describe only verified changes.
+
+   ```bash
+   python3 validation/verify_maven_publication.py X.Y.Z
+   ```
+
+   This checks all six public target artifacts and their POM coordinates. A successful upload
+   workflow can mean Central is still publishing; wait for public availability before announcing.
 10. Set the next development version to `X.Y.Z-SNAPSHOT` after publication, as in
    [Coil's release checklist](https://github.com/coil-kt/coil/blob/main/RELEASING.md).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -66,7 +66,8 @@ behavior across those releases.
    python3 validation/verify_maven_publication.py X.Y.Z
    ```
 
-   This checks all six public target artifacts and their POM coordinates. A successful upload
-   workflow can mean Central is still publishing; wait for public availability before announcing.
+   This checks all six public target artifacts and their POM and Gradle module coordinates.
+   A successful upload workflow can mean Central is still publishing; wait for public availability
+   before announcing.
 10. Set the next development version to `X.Y.Z-SNAPSHOT` after publication, as in
    [Coil's release checklist](https://github.com/coil-kt/coil/blob/main/RELEASING.md).

--- a/compose-experimental/README.md
+++ b/compose-experimental/README.md
@@ -15,11 +15,11 @@ Experimental / newest-Compose APIs evolve faster than Dejavu's core public behav
 regressions here lets them land immediately and move into the core accuracy suite once stable.
 
 The KMP targets build against the pinned Compose Multiplatform release baseline. Android builds and
-runs this module at **every supported Compose 1.11 BOM checkpoint**, alongside the legacy UI suite.
+runs this module at **every supported Android BOM checkpoint**, alongside the legacy UI suite.
 
 ## Currently covered
 
-The module currently exercises Compose 1.11's new APIs:
+The common suite exercises Compose 1.11 APIs:
 
 - the experimental non-lazy `Grid` layout,
 - the experimental `FlexBox` layout,
@@ -30,7 +30,7 @@ The module currently exercises Compose 1.11's new APIs:
 - `movableContentOf`.
 
 These run on JVM, iOS, Wasm, and Android instrumented. The Android suite runs against every
-supported 1.11 BOM.
+supported Android BOM.
 
 ## Test style
 
@@ -59,3 +59,17 @@ its coverage out of this module:
 2. Fold it into the accuracy suite — `ComposablePatternAccuracyTest` / `SideEffectAccuracyTest`.
 3. Update the compatibility docs (`docs/how-it-works.md`, `README.md`).
 4. Delete the now-redundant test (and any module-only helper it no longer needs) from here.
+
+## Compose 1.12 regressions
+
+The 1.12 baseline adds six tests in `src/compose112Test`: stable and changed keyed `SideEffect`,
+shrinking vararg effect keys, shrinking `remember` keys, frame assertions without implicit waits,
+and nested movable content with LinkBuffer enabled. Unkeyed `SideEffect` remains the ground-truth
+counter. The stable-key fixture deliberately recomposes four times even though its keyed callback
+never runs again; DejaVu must report four and reject an incorrect zero budget.
+
+The experimental `pressed` API accepts a `Style` in 1.11 and a block in 1.12. A small adapter in
+`src/compose111Test` or `src/compose112Test` preserves the same test behavior across this change.
+Gradle selects the source directory from the explicit Android BOM override, or the pinned baseline
+for KMP. Old Android checkpoints run 20 experimental tests; the 1.12 baseline runs 26. New APIs do
+not force the core library's supported Android floor upward.

--- a/compose-experimental/build.gradle.kts
+++ b/compose-experimental/build.gradle.kts
@@ -6,13 +6,13 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
 // compose-experimental: staging area for experimental-API recomposition coverage.
 //
 // This module hosts Dejavu recomposition tests for EXPERIMENTAL / newest-Compose
-// APIs (currently Compose 1.11's Grid, FlexBox, derivedMediaQuery/mediaQuery,
-// Styles, the LinkBuffer composer path, and movableContentOf).
+// APIs (Compose 1.11 layouts/styles and Compose 1.12 effects/testing behavior,
+// including LinkBuffer and movableContentOf).
 //
 // They live here instead of `:dejavu`'s commonTest so new API coverage can land
 // immediately and graduate into the core accuracy suite once those APIs stabilize.
 // KMP uses the pinned Compose Multiplatform baseline; Android builds and runs this
-// module at every supported Compose 1.11 BOM checkpoint.
+// module at every supported Android BOM checkpoint with matching API fixtures.
 //
 // PROMOTION: when an experimental API graduates to stable AND the `:dejavu` BOM
 // floor includes it, its composable + SideEffect-backed test is promoted into
@@ -50,9 +50,21 @@ kotlin {
   }
 
   iosSimulatorArm64()
-  wasmJs { browser() }
+  wasmJs {
+    browser()
+    // Compose 1.12 requires webpack bundling to load Skiko for browser UI tests.
+    binaries.executable()
+  }
 
   sourceSets {
+    // Keep the old Android compatibility suite compiling when a newer Compose API changes.
+    // KMP always uses the pinned release baseline; Android overrides select matching fixtures.
+    val testBom = providers.gradleProperty("composeBomVersion")
+      .orElse(libs.versions.composeBom).get()
+    commonTest.get().kotlin.srcDir(
+      if (testBom >= "2026.08.00") "src/compose112Test/kotlin" else "src/compose111Test/kotlin"
+    )
+
     commonMain.dependencies {
       implementation(project(":dejavu"))
       implementation(compose.runtime)
@@ -89,7 +101,7 @@ kotlin {
 
 android {
   namespace = "dejavu.experimental"
-  compileSdk = 36
+  compileSdk = 37
 
   defaultConfig {
     minSdk = 24

--- a/compose-experimental/src/commonTest/kotlin/dejavu/experimental/ExperimentalLayoutRegressionTest.kt
+++ b/compose-experimental/src/commonTest/kotlin/dejavu/experimental/ExperimentalLayoutRegressionTest.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.style.ExperimentalFoundationStyleApi
 import androidx.compose.foundation.style.MutableStyleState
 import androidx.compose.foundation.style.Style
 import androidx.compose.foundation.style.StyleScope
-import androidx.compose.foundation.style.pressed
 import androidx.compose.foundation.style.styleable
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
@@ -780,7 +779,7 @@ internal fun StyleRegressionScreen() {
         object : Style {
             override fun StyleScope.applyStyle() {
                 background(baseColor)
-                pressed(PressedStyle)
+                dejavuPressedStyle()
             }
         }
     }
@@ -812,7 +811,7 @@ internal fun StyleMisconfiguredScreen() {
         object : Style {
             override fun StyleScope.applyStyle() {
                 background(baseColor)
-                pressed(PressedStyle)
+                dejavuPressedStyle()
             }
         }
     }
@@ -827,12 +826,6 @@ internal fun StyleMisconfiguredScreen() {
                 .testTag("style_toggle")
                 .clickable { highlighted = !highlighted },
         )
-    }
-}
-
-private val PressedStyle = object : Style {
-    override fun StyleScope.applyStyle() {
-        background(Color.Red)
     }
 }
 

--- a/compose-experimental/src/compose111Test/kotlin/dejavu/experimental/StyleCompatibility.kt
+++ b/compose-experimental/src/compose111Test/kotlin/dejavu/experimental/StyleCompatibility.kt
@@ -1,0 +1,15 @@
+@file:OptIn(androidx.compose.foundation.style.ExperimentalFoundationStyleApi::class)
+
+package dejavu.experimental
+
+import androidx.compose.foundation.style.Style
+import androidx.compose.foundation.style.StyleScope
+import androidx.compose.foundation.style.pressed
+import androidx.compose.ui.graphics.Color
+
+// The experimental pressed API takes a Style in 1.11 and a block in 1.12.
+internal fun StyleScope.dejavuPressedStyle() {
+    pressed(object : Style {
+        override fun StyleScope.applyStyle() { background(Color.Red) }
+    })
+}

--- a/compose-experimental/src/compose112Test/kotlin/dejavu/experimental/Compose112RegressionTest.kt
+++ b/compose-experimental/src/compose112Test/kotlin/dejavu/experimental/Compose112RegressionTest.kt
@@ -1,0 +1,193 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class, androidx.compose.runtime.ExperimentalComposeApi::class)
+
+package dejavu.experimental
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposeRuntimeFlags
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.movableContentOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import dejavu.assertRecompositions
+import dejavu.assertStable
+import dejavu.resetRecompositionCounts
+import dejavu.runRecompositionTrackingUiTest
+import dejavu.setTrackedContent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/** Tests compiled only against Compose 1.12, with unkeyed effects as the count oracle. */
+class Compose112RegressionTest {
+    @Test
+    fun stableEffectKeyDoesNotHideIntentionalOverRecomposition() = runRecompositionTrackingUiTest {
+        GroundTruth.clear()
+        var tick by mutableIntStateOf(0)
+        setTrackedContent { KeyedEffectNode(tick, "same") }
+        snapshotCounts()
+
+        // tick is deliberately redundant work. A keyed SideEffect must NOT be our count oracle.
+        repeat(4) { runOnIdle { tick++ }; waitForIdle() }
+        assertEquals(4, GroundTruth.delta("keyed_node"))
+        assertEquals(0, GroundTruth.delta("keyed_callback"))
+        onNodeWithTag("keyed_node").assertRecompositions(exactly = GroundTruth.delta("keyed_node"))
+        assertFailsWith<AssertionError> { onNodeWithTag("keyed_node").assertStable() }
+    }
+
+    @Test
+    fun changedEffectKeyRunsOnceAndEqualStateWritesStayStable() = runRecompositionTrackingUiTest {
+        GroundTruth.clear()
+        var key by mutableStateOf("first")
+        setTrackedContent { KeyedEffectNode(0, key) }
+        snapshotCounts()
+        runOnIdle { key = "second" }
+        waitForIdle()
+        assertEquals(1, GroundTruth.delta("keyed_callback"))
+        assertEquals(1, GroundTruth.delta("keyed_node"))
+        onNodeWithTag("keyed_node").assertRecompositions(exactly = GroundTruth.delta("keyed_node"))
+
+        snapshotCounts()
+        runOnIdle { key = "second" }
+        waitForIdle()
+        assertEquals(0, GroundTruth.delta("keyed_callback"))
+        assertEquals(0, GroundTruth.delta("keyed_node"))
+        onNodeWithTag("keyed_node").assertStable()
+    }
+
+    @Test
+    fun shrinkingSideEffectKeysSchedulesEffectEvenWithTheSamePrefix() = runRecompositionTrackingUiTest {
+        GroundTruth.clear()
+        var keys by mutableStateOf(listOf("a", "b", "c", "d"))
+        setTrackedContent { VarargEffectNode(keys) }
+        snapshotCounts()
+        runOnIdle { keys = listOf("a", "b") }
+        waitForIdle()
+        assertEquals(1, GroundTruth.delta("vararg_callback"))
+        assertEquals(1, GroundTruth.delta("vararg_node"))
+        onNodeWithTag("vararg_node").assertRecompositions(exactly = GroundTruth.delta("vararg_node"))
+    }
+
+    @Test
+    fun shrinkingRememberKeysInvalidatesTheCachedValue() = runRecompositionTrackingUiTest {
+        GroundTruth.clear()
+        var keys by mutableStateOf(listOf("a", "b", "c", "d"))
+        setTrackedContent { RememberKeysNode(keys) }
+        snapshotCounts()
+        runOnIdle { keys = listOf("a", "b") }
+        waitForIdle()
+        onNodeWithTag("remember_node").assertTextEquals("a,b")
+        assertEquals(1, GroundTruth.delta("remember_calculation"))
+        assertEquals(1, GroundTruth.delta("remember_node"))
+        onNodeWithTag("remember_node").assertRecompositions(exactly = GroundTruth.delta("remember_node"))
+    }
+
+    @Test
+    fun assertionsWithoutImplicitWaitReadSettledFramesWithoutAdvancingTheClock() = runRecompositionTrackingUiTest {
+        GroundTruth.clear()
+        var tick by mutableIntStateOf(0)
+        setTrackedContent { KeyedEffectNode(tick, "same") }
+        snapshotCounts()
+        mainClock.autoAdvance = false
+        repeat(3) { index ->
+            runOnUiThread { tick++ }
+            mainClock.advanceTimeByFrame()
+            waitForIdle()
+            val frameTime = mainClock.currentTime
+            runOnUiThread {
+                runWithoutImplicitWait {
+                    onNodeWithTag("keyed_node").assertTextEquals("${index + 1}:same")
+                    assertEquals(index + 1, GroundTruth.delta("keyed_node"))
+                    onNodeWithTag("keyed_node").assertRecompositions(exactly = GroundTruth.delta("keyed_node"))
+                }
+            }
+            assertEquals(frameTime, mainClock.currentTime)
+        }
+    }
+
+    @Test
+    fun linkBufferNestedMovableContentPreservesStateAndTracksLaterUpdates() = runRecompositionTrackingUiTest {
+        GroundTruth.clear()
+        val previous = ComposeRuntimeFlags.isLinkBufferComposerEnabled
+        ComposeRuntimeFlags.isLinkBufferComposerEnabled = true
+        try {
+            var firstSlot by mutableStateOf(true)
+            setTrackedContent { NestedMovableScreen(firstSlot) }
+            onNodeWithTag("nested_child").performClick()
+            waitForIdle()
+            onNodeWithTag("nested_child").assertTextEquals("1")
+            snapshotCounts()
+            repeat(2) { runOnIdle { firstSlot = !firstSlot }; waitForIdle() }
+            onNodeWithTag("nested_child").assertTextEquals("1")
+            assertEquals(0, GroundTruth.delta("nested_child"))
+            onNodeWithTag("nested_child").assertStable()
+            onNodeWithTag("nested_child").performClick()
+            waitForIdle()
+            onNodeWithTag("nested_child").assertTextEquals("2")
+            assertEquals(1, GroundTruth.delta("nested_child"))
+            onNodeWithTag("nested_child").assertRecompositions(exactly = GroundTruth.delta("nested_child"))
+        } finally {
+            ComposeRuntimeFlags.isLinkBufferComposerEnabled = previous
+        }
+    }
+}
+
+private fun ComposeUiTest.snapshotCounts() {
+    waitForIdle()
+    resetRecompositionCounts()
+    GroundTruth.snapshotBaseline()
+}
+
+@Composable
+private fun KeyedEffectNode(tick: Int, key: String) {
+    SideEffect { GroundTruth.record("keyed_node") }
+    SideEffect(key) { GroundTruth.record("keyed_callback") }
+    BasicText("$tick:$key", Modifier.testTag("keyed_node"))
+}
+
+@Composable
+private fun VarargEffectNode(keys: List<String>) {
+    SideEffect { GroundTruth.record("vararg_node") }
+    SideEffect(*keys.toTypedArray()) { GroundTruth.record("vararg_callback") }
+    BasicText(keys.joinToString(), Modifier.testTag("vararg_node"))
+}
+
+@Composable
+private fun RememberKeysNode(keys: List<String>) {
+    SideEffect { GroundTruth.record("remember_node") }
+    val remembered = remember(*keys.toTypedArray()) {
+        GroundTruth.record("remember_calculation")
+        keys.joinToString(",")
+    }
+    BasicText(remembered, Modifier.testTag("remember_node"))
+}
+
+@Composable
+private fun NestedMovableScreen(firstSlot: Boolean) {
+    val inner = remember { movableContentOf { NestedCounter() } }
+    val outer = remember { movableContentOf { Column { inner() } } }
+    Row {
+        Box { if (firstSlot) outer() }
+        Box { if (!firstSlot) outer() }
+    }
+}
+
+@Composable
+private fun NestedCounter() {
+    var count by remember { mutableIntStateOf(0) }
+    SideEffect { GroundTruth.record("nested_child") }
+    BasicText("$count", Modifier.testTag("nested_child").clickable { count++ })
+}

--- a/compose-experimental/src/compose112Test/kotlin/dejavu/experimental/StyleCompatibility.kt
+++ b/compose-experimental/src/compose112Test/kotlin/dejavu/experimental/StyleCompatibility.kt
@@ -1,0 +1,12 @@
+@file:OptIn(androidx.compose.foundation.style.ExperimentalFoundationStyleApi::class)
+
+package dejavu.experimental
+
+import androidx.compose.foundation.style.StyleScope
+import androidx.compose.foundation.style.pressed
+import androidx.compose.ui.graphics.Color
+
+// The experimental pressed API takes a Style in 1.11 and a block in 1.12.
+internal fun StyleScope.dejavuPressedStyle() {
+    pressed { background(Color.Red) }
+}

--- a/dejavu/api/android/dejavu.api
+++ b/dejavu/api/android/dejavu.api
@@ -20,11 +20,13 @@ public final class dejavu/DejavuComposeTestRule : androidx/compose/ui/test/junit
 	public final fun getActivity ()Landroidx/activity/ComponentActivity;
 	public fun getDensity ()Landroidx/compose/ui/unit/Density;
 	public fun getMainClock ()Landroidx/compose/ui/test/MainTestClock;
+	public fun hasPendingWork ()Z
 	public fun onAllNodes (Landroidx/compose/ui/test/SemanticsMatcher;Z)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
 	public fun onNode (Landroidx/compose/ui/test/SemanticsMatcher;Z)Landroidx/compose/ui/test/SemanticsNodeInteraction;
 	public fun registerIdlingResource (Landroidx/compose/ui/test/IdlingResource;)V
 	public fun runOnIdle (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun runOnUiThread (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun runWithoutImplicitWait (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun setContent (Lkotlin/jvm/functions/Function2;)V
 	public fun unregisterIdlingResource (Landroidx/compose/ui/test/IdlingResource;)V
 	public fun waitForIdle ()V

--- a/dejavu/build.gradle.kts
+++ b/dejavu/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "me.mmckenna.dejavu"
-version = "0.4.0"
+version = "0.5.0"
 
 kotlin {
   explicitApi()
@@ -37,7 +37,11 @@ kotlin {
   iosArm64()
   iosSimulatorArm64()
 
-  wasmJs { browser() }
+  wasmJs {
+    browser()
+    // Compose 1.12 requires webpack bundling to load Skiko for browser UI tests.
+    binaries.executable()
+  }
 
   sourceSets {
     val iosMain by creating {
@@ -102,7 +106,7 @@ kotlin {
 
 android {
   namespace = "dejavu"
-  compileSdk = 36
+  compileSdk = 37
   defaultConfig {
     minSdk = 24
     consumerProguardFiles("consumer-rules.pro")

--- a/dejavu/src/androidMain/kotlin/dejavu/DejavuComposeTestRule.kt
+++ b/dejavu/src/androidMain/kotlin/dejavu/DejavuComposeTestRule.kt
@@ -1,11 +1,13 @@
 package dejavu
 
+import android.app.Application
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.platform.app.InstrumentationRegistry
 import dejavu.internal.Runtime
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
@@ -23,14 +25,13 @@ public class DejavuComposeTestRule<A : ComponentActivity>(
     public val activity: A get() = delegate.activity
 
     override fun apply(base: Statement, description: Description): Statement {
-        return delegate.apply(object : Statement() {
+        val trackedTest = delegate.apply(object : Statement() {
             override fun evaluate() {
                 // Setup touches Choreographer (via Runtime.seedActiveActivity), which
                 // requires a thread with a Looper. The wrapped Statement runs on
                 // compose-ui-test's TestDispatcher coroutine thread (no Looper), so
                 // hop to the instrumentation main thread for setup.
                 delegate.runOnUiThread {
-                    Dejavu.enable(delegate.activity.application)
                     Runtime.seedActiveActivity(delegate.activity)
                 }
                 delegate.waitForIdle()
@@ -38,6 +39,17 @@ public class DejavuComposeTestRule<A : ComponentActivity>(
                 base.evaluate()
             }
         }, description)
+        return object : Statement() {
+            override fun evaluate() {
+                // Install tracking before ActivityScenario launches the activity. Enabling
+                // it afterward can miss the initial inspection-table registration.
+                val instrumentation = InstrumentationRegistry.getInstrumentation()
+                instrumentation.runOnMainSync {
+                    Dejavu.enable(instrumentation.targetContext.applicationContext as Application)
+                }
+                trackedTest.evaluate()
+            }
+        }
     }
 }
 

--- a/dejavu/src/androidMain/kotlin/dejavu/internal/Platform.kt
+++ b/dejavu/src/androidMain/kotlin/dejavu/internal/Platform.kt
@@ -21,11 +21,13 @@ internal actual fun isLoggingEnabled(): Boolean = Runtime.isLoggingEnabled
 
 internal actual fun currentCompositionsSnapshot(): Set<CompositionData> {
     val runtimeSnapshots = Runtime.currentCompositionsSnapshot()
-    if (runtimeSnapshots.isNotEmpty()) return runtimeSnapshots
-
-    return synchronized(DejavuTracer.inspectionTablesLock) {
+    val explicitSnapshots = synchronized(DejavuTracer.inspectionTablesLock) {
         DejavuTracer.inspectionTables.toSet()
     }
+    // The Android lifecycle tracker can be enabled by an earlier rule in the same process.
+    // setTrackedContent supplies a separate inspection collection for its subcomposition;
+    // activity tables alone do not include that collection. Keep both views of the tree.
+    return runtimeSnapshots + explicitSnapshots
 }
 
 internal actual fun createInspectionTables(): MutableSet<CompositionData> =

--- a/dejavu/src/commonMain/kotlin/dejavu/ComposeUiTestIntegration.kt
+++ b/dejavu/src/commonMain/kotlin/dejavu/ComposeUiTestIntegration.kt
@@ -47,6 +47,8 @@ import kotlinx.coroutines.test.TestResult
 public fun runRecompositionTrackingUiTest(
     block: suspend ComposeUiTest.() -> Unit,
 ): TestResult = runComposeUiTest {
+    val previouslyEnabled = DejavuTracer.enabled
+    val previousInspectorInfoEnabled = isDebugInspectorInfoEnabled
     isDebugInspectorInfoEnabled = true
     DejavuTracer.enabled = true
     Composer.setTracer(DejavuTracer)
@@ -56,9 +58,11 @@ public fun runRecompositionTrackingUiTest(
     try {
         block()
     } finally {
-        DejavuTracer.enabled = false
-        Composer.setTracer(null)
-        isDebugInspectorInfoEnabled = false
+        // Android's activity runtime may already own tracking. Restore that state so
+        // a later Android rule does not inherit an enabled runtime with a removed tracer.
+        DejavuTracer.enabled = previouslyEnabled
+        Composer.setTracer(if (previouslyEnabled) DejavuTracer else null)
+        isDebugInspectorInfoEnabled = previousInspectorInfoEnabled
         synchronized(DejavuTracer.inspectionTablesLock) { DejavuTracer.inspectionTables.clear() }
     }
 }

--- a/demo-shared/build.gradle.kts
+++ b/demo-shared/build.gradle.kts
@@ -76,7 +76,7 @@ kotlin {
 
 android {
   namespace = "demo.app.shared"
-  compileSdk = 36
+  compileSdk = 37
   defaultConfig {
     minSdk = 24
   }

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
   namespace = "demo.app"
-  compileSdk = 36
+  compileSdk = 37
   defaultConfig {
     applicationId = "demo.app"
     minSdk = 24

--- a/demo/src/androidTest/java/demo/app/MixedHarnessRegressionTest.kt
+++ b/demo/src/androidTest/java/demo/app/MixedHarnessRegressionTest.kt
@@ -1,0 +1,56 @@
+package demo.app
+
+import android.app.Application
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.platform.app.InstrumentationRegistry
+import dejavu.Dejavu
+import dejavu.assertRecompositions
+import dejavu.assertStable
+import dejavu.resetRecompositionCounts
+import dejavu.runRecompositionTrackingUiTest
+import dejavu.setTrackedContent
+import org.junit.Test
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+
+/** Both public harnesses can run in the same instrumentation process. */
+@OptIn(ExperimentalTestApi::class)
+class MixedHarnessRegressionTest {
+    @Test
+    fun enabledAndroidRuntimeKeepsTheKmpHelpersInspectionTablesVisible() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.runOnMainSync {
+            Dejavu.enable(instrumentation.targetContext.applicationContext as Application)
+        }
+        try {
+            runRecompositionTrackingUiTest {
+                val value = mutableIntStateOf(0)
+                var compositions = 0
+                setTrackedContent { MixedHarnessValue(value.intValue) { compositions++ } }
+                waitForIdle()
+                val baseline = compositions
+                resetRecompositionCounts()
+                runOnIdle { value.intValue++ }
+                waitForIdle()
+                assertEquals(1, compositions - baseline)
+                onNodeWithTag("mixed_harness_value").assertRecompositions(exactly = compositions - baseline)
+                assertThrows(AssertionError::class.java) { onNodeWithTag("mixed_harness_value").assertStable() }
+            }
+        } finally {
+            instrumentation.runOnMainSync { Dejavu.disable() }
+        }
+    }
+}
+
+@Composable
+private fun MixedHarnessValue(value: Int, onComposition: () -> Unit) {
+    SideEffect(onComposition)
+    BasicText("$value", Modifier.testTag("mixed_harness_value"))
+}

--- a/demo/src/androidTest/java/demo/app/MixedHarnessRegressionTest.kt
+++ b/demo/src/androidTest/java/demo/app/MixedHarnessRegressionTest.kt
@@ -13,12 +13,15 @@ import androidx.test.platform.app.InstrumentationRegistry
 import dejavu.Dejavu
 import dejavu.assertRecompositions
 import dejavu.assertStable
+import dejavu.createRecompositionTrackingRule
 import dejavu.resetRecompositionCounts
 import dejavu.runRecompositionTrackingUiTest
 import dejavu.setTrackedContent
 import org.junit.Test
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
 
 /** Both public harnesses can run in the same instrumentation process. */
 @OptIn(ExperimentalTestApi::class)
@@ -43,6 +46,26 @@ class MixedHarnessRegressionTest {
                 onNodeWithTag("mixed_harness_value").assertRecompositions(exactly = compositions - baseline)
                 assertThrows(AssertionError::class.java) { onNodeWithTag("mixed_harness_value").assertStable() }
             }
+            // The next Android rule must still track after the helper has cleaned up.
+            val rule = createRecompositionTrackingRule()
+            rule.apply(object : Statement() {
+                override fun evaluate() {
+                    val value = mutableIntStateOf(0)
+                    var compositions = 0
+                    rule.setContent { MixedHarnessValue(value.intValue) { compositions++ } }
+                    rule.waitForIdle()
+                    val baseline = compositions
+                    rule.resetRecompositionCounts()
+                    rule.runOnIdle { value.intValue++ }
+                    rule.waitForIdle()
+                    assertEquals(1, compositions - baseline)
+                    rule.onNodeWithTag("mixed_harness_value")
+                        .assertRecompositions(exactly = compositions - baseline)
+                    assertThrows(AssertionError::class.java) {
+                        rule.onNodeWithTag("mixed_harness_value").assertStable()
+                    }
+                }
+            }, Description.createTestDescription(javaClass, "androidRuleAfterKmpHelper")).evaluate()
         } finally {
             instrumentation.runOnMainSync { Dejavu.disable() }
         }

--- a/demo/src/androidTest/java/demo/app/RunTestRuleSetupTest.kt
+++ b/demo/src/androidTest/java/demo/app/RunTestRuleSetupTest.kt
@@ -2,6 +2,7 @@ package demo.app
 
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.assertTextEquals
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import dejavu.Dejavu
@@ -30,7 +31,11 @@ class RunTestRuleSetupTest {
     fun ruleSetup_succeedsInsideRunTest() = runTest {
         composeTestRule.onNodeWithTag("counter_value").assertStable()
     }
+}
 
+/** A manual rule must own the only test environment and activity during this regression. */
+@RunWith(AndroidJUnit4::class)
+class RunTestRuleDisabledRuntimeTest {
     @Test
     fun ruleSetup_succeedsWhenDejavuWasNotPreEnabledByTheApp() {
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
@@ -45,12 +50,13 @@ class RunTestRuleSetupTest {
                     GroundTruthCounters.reset()
                     rule.onNodeWithTag("inc_button").performClick()
                     rule.waitForIdle()
+                    rule.onNodeWithTag("counter_value").assertTextEquals("Value: 1")
                     assertEquals(1, GroundTruthCounters.get("counter_value"))
                     rule.onNodeWithTag("counter_value").assertRecompositions(exactly = 1)
                 }
             },
             Description.createTestDescription(
-                RunTestRuleSetupTest::class.java,
+                RunTestRuleDisabledRuntimeTest::class.java,
                 "ruleSetup_succeedsWhenDejavuWasNotPreEnabledByTheApp",
             ),
         )

--- a/demo/src/androidTest/java/demo/app/RunTestRuleSetupTest.kt
+++ b/demo/src/androidTest/java/demo/app/RunTestRuleSetupTest.kt
@@ -1,14 +1,17 @@
 package demo.app
 
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import dejavu.Dejavu
 import dejavu.assertStable
+import dejavu.assertRecompositions
 import dejavu.createRecompositionTrackingRule
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.Assert.assertEquals
 import org.junit.runner.Description
 import org.junit.runner.RunWith
 import org.junit.runners.model.Statement
@@ -39,6 +42,11 @@ class RunTestRuleSetupTest {
             object : Statement() {
                 override fun evaluate() {
                     rule.onNodeWithTag("counter_value").assertStable()
+                    GroundTruthCounters.reset()
+                    rule.onNodeWithTag("inc_button").performClick()
+                    rule.waitForIdle()
+                    assertEquals(1, GroundTruthCounters.get("counter_value"))
+                    rule.onNodeWithTag("counter_value").assertRecompositions(exactly = 1)
                 }
             },
             Description.createTestDescription(

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@
 ```kotlin
 // app/build.gradle.kts
 dependencies {
-    androidTestImplementation("me.mmckenna.dejavu:dejavu:0.4.0")
+    androidTestImplementation("me.mmckenna.dejavu:dejavu:0.5.0")
 }
 ```
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -30,6 +30,11 @@ is Compose 1.11 (BOM 2026.05.00). CI derives its matrix from the `composeBomComp
 Multiplatform artifacts cannot silently replace the runtime under test. `CompositionObserver`
 support is unconditional; there is no degraded or observer-excluded build path.
 
+Android 0.5.0 artifacts declare minimum compile SDK 37. To retain an older Android Compose line,
+use `enforcedPlatform` for the selected BOM in both application and instrumentation dependencies;
+a regular platform can allow the newer transitive baseline to win. DejaVu 0.4.0 remains the
+Compose Multiplatform 1.11 / compile SDK 36 baseline.
+
 ## Compose Testing v2
 
 Dejavu's test harness uses the Compose testing **v2** APIs (`runComposeUiTest` /

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -12,21 +12,21 @@ All tracking runs in the app process on the main thread, directly accessible to 
 
 ## Compatibility
 
-**Minimum supported Compose for Dejavu 0.4.x: 1.11 (BOM 2026.05.00).** The 0.4.x test harness uses
+**Minimum supported Compose for Dejavu 0.5.x: 1.11 (BOM 2026.05.00).** The 0.5.x test harness uses
 the Compose testing v2 APIs introduced with this line. For Compose 1.10, use Dejavu 0.3.1. This
 keeps that older Compose line available without letting newer transitive artifacts mask an
-unsupported combination. Requires Kotlin 2.3+ with the Compose compiler plugin.
+unsupported combination. Validated with Kotlin 2.4.0 and its Compose compiler plugin.
 
-| Compose BOM | Compose | Kotlin | Status |
+| Compose BOM | Compose | Kotlin tested | Status |
 |---|---|---|---|
-| 2026.05.00 | 1.11.x | 2.3.x+ | Minimum |
-| 2026.06.00 | 1.11.x | 2.3.x+ | Previous 1.11 checkpoint |
-| 2026.06.01 | 1.11.x | 2.3.x+ | Release baseline |
+| 2026.05.00 | 1.11.x | 2.4.0 | Minimum |
+| 2026.06.01 | 1.11.x | 2.4.0 | Latest 1.11 checkpoint |
+| 2026.08.00 | 1.12.x | 2.4.0 | Release baseline |
 
-The release baseline is Compose Multiplatform 1.11.1 and Android Compose BOM 2026.06.01; the floor
+The release baseline is Compose Multiplatform 1.12.0 and Android Compose BOM 2026.08.00; the floor
 is Compose 1.11 (BOM 2026.05.00). CI derives its matrix from the `composeBomCompat*` checkpoints and
-`composeBom` baseline in `gradle/libs.versions.toml`, currently 2026.05.00, 2026.06.00, and
-2026.06.01. Compatibility runs enforce the selected BOM so newer transitive Compose
+`composeBom` baseline in `gradle/libs.versions.toml`, currently 2026.05.00, 2026.06.01, and
+2026.08.00. Compatibility runs enforce the selected BOM so newer transitive Compose
 Multiplatform artifacts cannot silently replace the runtime under test. `CompositionObserver`
 support is unconditional; there is no degraded or observer-excluded build path.
 
@@ -38,7 +38,7 @@ Dejavu's test harness uses the Compose testing **v2** APIs (`runComposeUiTest` /
 verified to be unchanged on JVM under the new dispatcher, so no rebaselining of test expectations
 was required.
 
-## Compose 1.11 Coverage
+## New Compose API Coverage
 
 The `compose-experimental` module is a staging area for recomposition coverage of experimental /
 newest-Compose APIs before they graduate into the core accuracy suite. It exercises Dejavu against
@@ -46,7 +46,18 @@ Compose 1.11's new composables and runtime paths: the experimental `Grid` and `F
 `derivedMediaQuery` / `mediaQuery` adaptive breakpoints, the Styles API
 (`androidx.compose.foundation.style`), `movableContentOf`, and the experimental LinkBuffer composer
 runtime path (`ComposeRuntimeFlags.isLinkBufferComposerEnabled`). These tests run on JVM, iOS,
-Wasm, and Android instrumented; Android runs every supported 1.11 BOM checkpoint.
+Wasm, and Android instrumented; Android runs every supported BOM checkpoint.
+
+### Compose 1.12 Coverage
+
+The Compose 1.12 baseline additionally validates keyed `SideEffect`, shrinking vararg effect and
+`remember` keys, assertions using `runWithoutImplicitWait`, and nested movable content under
+LinkBuffer. Exact counters continue using unkeyed `SideEffect`, including a deliberately inefficient
+fixture whose keyed callback stays quiet during four recompositions. The experimental suite runs
+26 tests on 1.12 and retains 20 on the supported Android 1.11 checkpoints.
+
+`DejavuComposeTestRule` delegates the new `hasPendingWork` and `runWithoutImplicitWait` methods on
+Compose 1.12. These methods require 1.12; the existing rule API remains covered on Android 1.11.
 
 ## Known Limitations
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,9 +28,9 @@ Dejavu is a test-only library that turns recomposition behavior into assertions.
 - **Rich diagnostics** — source location, recomposition timeline, parameter diffs, causality analysis
 - **Per-instance tracking** — multiple instances of the same composable get independent counters
 
-Dejavu 0.4.x supports Compose 1.11 (BOM 2026.05.00 through 2026.06.01); the release baseline is
-Compose Multiplatform 1.11.1 and Android Compose BOM 2026.06.01. For Compose 1.10, use Dejavu
-0.3.1. The 0.4.x test harness uses the Compose testing v2 APIs (which default to
+Dejavu 0.5.x supports Compose 1.11–1.12 (BOM 2026.05.00 through 2026.08.00); the release baseline is
+Compose Multiplatform 1.12.0 and Android Compose BOM 2026.08.00. For Compose 1.10, use Dejavu
+0.3.1. The 0.5.x test harness uses the Compose testing v2 APIs (which default to
 `StandardTestDispatcher`). Instrumented BOM gates run the supported BOM range, and the
 `compose-experimental` module (a staging area for experimental-API
 recomposition coverage) validates Dejavu against Compose 1.11's new composables (`Grid`, `FlexBox`,
@@ -54,3 +54,7 @@ Install the bundled Dejavu skills globally — they cover initial install (`deja
 ```
 
 See [Use Cases → Give AI Agents a Recomposition Signal](use-cases.md#give-ai-agents-a-recomposition-signal) for what each skill does.
+
+DejaVu 0.5.0 also covers Compose 1.12 keyed effects, shrinking `remember` keys, test synchronization,
+and nested movable content. The Android Compose 1.11 support floor is retained; see
+[compatibility and coverage](how-it-works.md) for the tested version matrix.

--- a/docs/releases/0.4.0.md
+++ b/docs/releases/0.4.0.md
@@ -82,4 +82,18 @@ uses this checked-in record and the exact tagged commit SHA instead of rerunning
 - [GitHub release](https://github.com/mttmcknn/dejavu/releases/tag/v0.4.0)
 - [Shared tracker and social drafts](https://docs.google.com/document/d/1nfIzsfxz0ze_rTy5EKO0vG8TO_JyXDdricco7q5oyfY/edit)
 
-Publication is verified separately after Maven Central exposes all target artifacts.
+All six target artifacts and their POM coordinates were verified publicly on Maven Central
+on September 9, 2026 at 16:24 UTC. The GitHub release was published at 16:25 UTC, and
+[versioned documentation](https://dejavu.mmckenna.me/0.4.0/) is live.
+
+The upload workflow completed at 15:08 UTC while Central still reported publication in progress;
+the GitHub release remained a draft until the public artifact checks passed. The shared tracker
+contains social drafts; no social posts were sent.
+
+## Known integration limitation
+
+Later packaged-consumer checks found that mixing Android rules and KMP helpers in one process
+can hide inspection tables or leave tracing disabled in 0.4.0. Enabling tracking after activity
+launch can also miss initial inspection registration. DejaVu 0.5.0 fixes these lifecycle paths
+and verifies exact counts with independent `SideEffect` counters. The 0.4.0 GitHub release notes
+record the mixed-harness limitation.

--- a/docs/releases/0.5.0.md
+++ b/docs/releases/0.5.0.md
@@ -1,6 +1,6 @@
 # DejaVu 0.5.0 release validation
 
-Status: pending
+Status: passed
 
 Validation date: September 9, 2026.
 
@@ -23,7 +23,7 @@ That run completed the multiplatform suites and the minimum Android BOM. The Jun
 exposed a test setup problem: the new first-update assertion nested two Compose test environments.
 The manual-rule regression was moved into its own class and now also asserts the displayed value.
 It passed in isolation on both older BOMs after this test-only correction. The June and August
-checkpoints are then run in separate build directories and emulators with the final fixture:
+checkpoints were then run in separate build directories and emulators with the final fixture:
 
 ```bash
 ANDROID_SERIAL=emulator-5554 ./gradlew -q --console=plain -PrerunTests \
@@ -38,7 +38,7 @@ python3 validation/verify_test_results.py \
   compose-experimental/build/outputs/androidTest-results/connected
 ```
 
-The same commands run for BOM 2026.08.00 in the independent copy with `emulator-5556`.
+The same commands passed for BOM 2026.08.00 in the independent copy with `emulator-5556`.
 Reports from each checkpoint are preserved under `build/release-validation/0.5.0-final`.
 
 | Suite | Tests | Failures | Skips |
@@ -50,8 +50,8 @@ Reports from each checkpoint are preserved under `build/release-validation/0.5.0
 | Experimental iOS simulator arm64 | 26 | 0 | 0 |
 | Experimental Wasm in Chrome | 26 | 0 | 0 |
 | Android BOM 2026.05.00 unit / demo / experimental | 27 / 225 / 20 | 0 | 0 |
-| Android BOM 2026.06.01 unit / demo / experimental | 27 / 225 / 20 | pending | pending |
-| Android BOM 2026.08.00 unit / demo / experimental | 27 / 225 / 26 | pending | pending |
+| Android BOM 2026.06.01 unit / demo / experimental | 27 / 225 / 20 | 0 | 0 |
+| Android BOM 2026.08.00 unit / demo / experimental | 27 / 225 / 26 | 0 | 0 |
 
 The full gate runs tests freshly, checks public API snapshots and lint, compiles all supported
 library targets, and builds Android test APKs plus desktop/Wasm demos. Older Android BOMs are

--- a/docs/releases/0.5.0.md
+++ b/docs/releases/0.5.0.md
@@ -5,6 +5,8 @@ Status: pending
 Validation date: September 9, 2026.
 
 Implementation candidate: `3c949ab335c3b822ba1308201f8b8c7ab8976d80`.
+Final Android test fixture: `fa817151eb3d5d49574ffaa7f90b3203b4ff2a18`.
+Production library sources are unchanged between these commits.
 The release builds against stable Compose Multiplatform 1.12.0 and Android BOM 2026.08.00
 (Compose runtime 1.12.0), retaining the Android 1.11 support floor. Kotlin remains 2.4.0;
 AGP is 9.4.0, Gradle is 9.6.0, and Android compile SDK is 37.
@@ -17,6 +19,28 @@ DEJAVU_VALIDATION_DIR=build/release-validation/0.5.0-final \
 ./test.sh --all-boms
 ```
 
+That run completed the multiplatform suites and the minimum Android BOM. The June checkpoint
+exposed a test setup problem: the new first-update assertion nested two Compose test environments.
+The manual-rule regression was moved into its own class and now also asserts the displayed value.
+It passed in isolation on both older BOMs after this test-only correction. The June and August
+checkpoints are then run in separate build directories and emulators with the final fixture:
+
+```bash
+ANDROID_SERIAL=emulator-5554 ./gradlew -q --console=plain -PrerunTests \
+  :dejavu:compileDebugKotlin :dejavu:testDebugUnitTest \
+  :demo:assembleDebug :demo:assembleDebugAndroidTest \
+  :compose-experimental:assembleDebug :compose-experimental:assembleDebugAndroidTest \
+  :demo:connectedDebugAndroidTest :compose-experimental:connectedDebugAndroidTest \
+  -PcomposeBomVersion=2026.06.01
+python3 validation/verify_test_results.py \
+  dejavu/build/test-results/testDebugUnitTest \
+  demo/build/outputs/androidTest-results/connected \
+  compose-experimental/build/outputs/androidTest-results/connected
+```
+
+The same commands run for BOM 2026.08.00 in the independent copy with `emulator-5556`.
+Reports from each checkpoint are preserved under `build/release-validation/0.5.0-final`.
+
 | Suite | Tests | Failures | Skips |
 | --- | ---: | ---: | ---: |
 | Core JVM | 229 | 0 | 0 |
@@ -25,7 +49,7 @@ DEJAVU_VALIDATION_DIR=build/release-validation/0.5.0-final \
 | Experimental JVM | 26 | 0 | 0 |
 | Experimental iOS simulator arm64 | 26 | 0 | 0 |
 | Experimental Wasm in Chrome | 26 | 0 | 0 |
-| Android BOM 2026.05.00 unit / demo / experimental | 27 / 225 / 20 | pending | pending |
+| Android BOM 2026.05.00 unit / demo / experimental | 27 / 225 / 20 | 0 | 0 |
 | Android BOM 2026.06.01 unit / demo / experimental | 27 / 225 / 20 | pending | pending |
 | Android BOM 2026.08.00 unit / demo / experimental | 27 / 225 / 26 | pending | pending |
 
@@ -54,9 +78,11 @@ ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SERIAL=emulator-5556 \
   -PdejavuVersion=0.5.0 -PcomposeBomVersion=2026.05.00
 ```
 
-Repeat the Android consumer command at each checkpoint and baseline, preserving reports before
-switching BOMs. JVM, iOS simulator, and Wasm each passed their packaged-artifact smoke test.
-The final packaged artifacts passed two Android tests on each older BOM and three on the 1.12 baseline using a clean API 36 emulator. JVM, iOS simulator, and Wasm each freshly passed one smoke test after the lifecycle fixes. The report verifier confirmed no failures, errors, or skips. Reports are preserved under `build/release-validation/0.5.0-final/consumer`.
+The Android consumer command was repeated at every checkpoint and baseline. The final packaged
+artifacts passed two Android tests on each older BOM and three on the 1.12 baseline using a clean
+API 36 emulator. JVM, iOS simulator, and Wasm each freshly passed one smoke test after the lifecycle
+fixes. The report verifier confirmed no failures, errors, or skips. Reports are preserved under
+`build/release-validation/0.5.0-final/consumer`.
 
 `dependencyInsight` confirms the consumer resolves `runtime-android:1.11.1` at the minimum BOM,
 including when the dependency is the published 0.5.0 Android binary built against 1.12.
@@ -71,8 +97,9 @@ checks existing rule behavior on the older runtimes and the new methods on the r
 ## Environment and coverage limits
 
 - macOS Apple Silicon; JetBrains JDK 21 toolchain; JVM bytecode target 17.
-- Pixel 10 Android emulator, API 37, arm64, 16 KB pages (`emulator-5554`).
-- Packaged Android consumers: clean Dejavu_Release_API36 emulator, API 36, arm64 (`emulator-5556`).
+- Older Android BOM source suites: Pixel 10 emulator, API 37, arm64, 16 KB pages (`emulator-5554`).
+- Android 1.12 source suite and packaged consumers: clean Dejavu_Release_API36 emulator, API 36,
+  arm64, 4 KB pages (`emulator-5556`).
 - iOS 26.5 simulator arm64 and headless Chrome for Wasm.
 - Historical hosted Android API 26 and 31 device jobs were not repeated locally.
 - iOS device arm64 was compiled and packaged; UI tests run on the simulator.
@@ -81,7 +108,7 @@ checks existing rule behavior on the older runtimes and the new methods on the r
   remains part of the accuracy suite.
 
 Passing local checks replace repeated hosted test matrices under the approved CI budget policy.
-The final matrix is repeated after the Android mixed-harness inspection-table fix. The original
+The final matrix and packaged consumers use the Android lifecycle fixes. The original
 consumer fixture was also changed to use a named composable with independent SideEffect counts,
 and its Espresso dependency is aligned with the main suite for API 37.
 
@@ -97,5 +124,10 @@ Maven Central availability is checked separately after publication.
 
 The packaged Android consumer exposed a real integration failure: each harness passed alone, but
 starting the Android rule before the KMP helper caused activity inspection tables to hide the
-helper's explicit tables. The library now combines both snapshot sources. The helper also restores the previously active tracer and inspector settings when it exits; otherwise a later Android rule could see the runtime as enabled while tracing was disabled. The Android rule now enables tracking before activity launch so the first composition registers inspection tables even after a previous test disabled tracking. Dedicated Android regressions failed before the fixes and check the full rule/helper/rule sequence plus the first update after disabled-runtime setup, including independent SideEffect counts and expected budget failures.
-The final matrix and packaged artifacts are revalidated with this fix included.
+helper's explicit tables. The library now combines both snapshot sources. The helper also restores
+the previously active tracer and inspector settings when it exits; otherwise a later Android rule
+could see the runtime as enabled while tracing was disabled. The Android rule enables tracking
+before activity launch so the first composition registers inspection tables even after a previous
+test disabled tracking. Dedicated regressions failed before the fixes and check the full
+rule/helper/rule sequence plus the first update after disabled-runtime setup, including independent
+`SideEffect` counts and expected budget failures.

--- a/docs/releases/0.5.0.md
+++ b/docs/releases/0.5.0.md
@@ -1,0 +1,101 @@
+# DejaVu 0.5.0 release validation
+
+Status: pending
+
+Validation date: September 9, 2026.
+
+Implementation candidate: `3c949ab335c3b822ba1308201f8b8c7ab8976d80`.
+The release builds against stable Compose Multiplatform 1.12.0 and Android BOM 2026.08.00
+(Compose runtime 1.12.0), retaining the Android 1.11 support floor. Kotlin remains 2.4.0;
+AGP is 9.4.0, Gradle is 9.6.0, and Android compile SDK is 37.
+
+## Local release suite
+
+```bash
+ANDROID_SERIAL=emulator-5554 \
+DEJAVU_VALIDATION_DIR=build/release-validation/0.5.0-final \
+./test.sh --all-boms
+```
+
+| Suite | Tests | Failures | Skips |
+| --- | ---: | ---: | ---: |
+| Core JVM | 229 | 0 | 0 |
+| Core iOS simulator arm64 | 229 | 0 | 0 |
+| Core Wasm in Chrome | 229 | 0 | 0 |
+| Experimental JVM | 26 | 0 | 0 |
+| Experimental iOS simulator arm64 | 26 | 0 | 0 |
+| Experimental Wasm in Chrome | 26 | 0 | 0 |
+| Android BOM 2026.05.00 unit / demo / experimental | 27 / 225 / 20 | pending | pending |
+| Android BOM 2026.06.01 unit / demo / experimental | 27 / 225 / 20 | pending | pending |
+| Android BOM 2026.08.00 unit / demo / experimental | 27 / 225 / 26 | pending | pending |
+
+The full gate runs tests freshly, checks public API snapshots and lint, compiles all supported
+library targets, and builds Android test APKs plus desktop/Wasm demos. Older Android BOMs are
+enforced during compatibility checks. XML reports are preserved separately per BOM.
+
+The 1.12 experimental suite adds six tests for keyed effects, shrinking effect and remember keys,
+frame assertions without implicit waits, and nested movable content under LinkBuffer. The
+stable-key fixture deliberately recomposes four times while its keyed callback stays quiet;
+unkeyed `SideEffect` remains the oracle. The same 20 original experimental tests run on older
+Android checkpoints with an adapter for the changed experimental Styles API.
+
+## Packaged artifact checks
+
+All six 0.5.0 Maven publications were built locally once at the 1.12 baseline. The standalone
+[consumer build](../../validation/consumer/README.md) consumes those artifacts rather than
+recompiling the DejaVu source for each older runtime.
+
+```bash
+./gradlew :dejavu:publishToMavenLocal --no-configuration-cache
+ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew -p validation/consumer \
+  jvmTest iosSimulatorArm64Test wasmJsBrowserTest -PdejavuVersion=0.5.0 -PrerunTests
+ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SERIAL=emulator-5556 \
+  ./gradlew -p validation/consumer connectedDebugAndroidTest \
+  -PdejavuVersion=0.5.0 -PcomposeBomVersion=2026.05.00
+```
+
+Repeat the Android consumer command at each checkpoint and baseline, preserving reports before
+switching BOMs. JVM, iOS simulator, and Wasm each passed their packaged-artifact smoke test.
+The final packaged artifacts passed two Android tests on each older BOM and three on the 1.12 baseline using a clean API 36 emulator. JVM, iOS simulator, and Wasm each freshly passed one smoke test after the lifecycle fixes. The report verifier confirmed no failures, errors, or skips. Reports are preserved under `build/release-validation/0.5.0-final/consumer`.
+
+`dependencyInsight` confirms the consumer resolves `runtime-android:1.11.1` at the minimum BOM,
+including when the dependency is the published 0.5.0 Android binary built against 1.12.
+The AAR metadata declares `minCompileSdk=37`: Android consumers must use compile SDK 37.
+Retaining an older Compose line requires an enforced BOM in application and instrumentation
+dependencies; ordinary platform resolution may select the newer transitive baseline.
+
+The public API snapshot adds only delegated Android rule methods `hasPendingWork` and
+`runWithoutImplicitWait`. Calling these new methods requires Compose 1.12. The packaged consumer
+checks existing rule behavior on the older runtimes and the new methods on the release baseline.
+
+## Environment and coverage limits
+
+- macOS Apple Silicon; JetBrains JDK 21 toolchain; JVM bytecode target 17.
+- Pixel 10 Android emulator, API 37, arm64, 16 KB pages (`emulator-5554`).
+- Packaged Android consumers: clean Dejavu_Release_API36 emulator, API 36, arm64 (`emulator-5556`).
+- iOS 26.5 simulator arm64 and headless Chrome for Wasm.
+- Historical hosted Android API 26 and 31 device jobs were not repeated locally.
+- iOS device arm64 was compiled and packaged; UI tests run on the simulator.
+- Off-screen lazy items must be brought into view before assertions. Non-Android multi-instance
+  attribution can fall back to shared function counts; independent function-level ground truth
+  remains part of the accuracy suite.
+
+Passing local checks replace repeated hosted test matrices under the approved CI budget policy.
+The final matrix is repeated after the Android mixed-harness inspection-table fix. The original
+consumer fixture was also changed to use a named composable with independent SideEffect counts,
+and its Espresso dependency is aligned with the main suite for API 37.
+
+## Publication tracking
+
+- [Release PR](https://github.com/mttmcknn/dejavu/pull/135)
+- [GitHub release](https://github.com/mttmcknn/dejavu/releases/tag/v0.5.0)
+- [Shared tracker and social drafts](https://docs.google.com/document/d/1nfIzsfxz0ze_rTy5EKO0vG8TO_JyXDdricco7q5oyfY/edit)
+
+Maven Central availability is checked separately after publication.
+
+## Mixed harness regression
+
+The packaged Android consumer exposed a real integration failure: each harness passed alone, but
+starting the Android rule before the KMP helper caused activity inspection tables to hide the
+helper's explicit tables. The library now combines both snapshot sources. The helper also restores the previously active tracer and inspector settings when it exits; otherwise a later Android rule could see the runtime as enabled while tracing was disabled. The Android rule now enables tracking before activity launch so the first composition registers inspection tables even after a previous test disabled tracking. Dedicated Android regressions failed before the fixes and check the full rule/helper/rule sequence plus the first update after disabled-runtime setup, including independent SideEffect counts and expected budget failures.
+The final matrix and packaged artifacts are revalidated with this fix included.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.1.0"
+agp = "9.4.0"
 kotlin = "2.4.0"
 coreKtx = "1.19.0"
 junit = "4.13.2"
@@ -8,11 +8,11 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.11.0"
 activityCompose = "1.13.0"
 # The release baseline follows the latest validated stable Android Compose BOM.
-composeBom = "2026.06.01"
+composeBom = "2026.08.00"
 # Compatibility checkpoints stay pinned until the documented support floor moves.
 composeBomCompatMinimum = "2026.05.00"
-composeBomCompatPrevious111 = "2026.06.00"
-composeMultiplatform = "1.11.1"
+composeBomCompatPrevious111 = "2026.06.01"
+composeMultiplatform = "1.12.0"
 coroutinesAndroid = "1.11.0"
 atomicfu = "0.33.0"
 binary-compatibility-validator = "0.17.0"

--- a/test.sh
+++ b/test.sh
@@ -59,6 +59,7 @@ fi
 
 for module in dejavu compose-experimental; do
   for task in jvmTest iosSimulatorArm64Test wasmJsBrowserTest; do
+    python3 validation/verify_test_results.py "$module/build/test-results/$task"
     mkdir -p "$validation_dir/$module/$task"
     cp -R "$module/build/test-results/$task/." "$validation_dir/$module/$task/"
   done
@@ -74,6 +75,7 @@ for bom in "${boms[@]}"; do
     :compose-experimental:assembleDebug \
     :compose-experimental:assembleDebugAndroidTest \
     -PcomposeBomVersion="$bom"
+  python3 validation/verify_test_results.py dejavu/build/test-results/testDebugUnitTest
   mkdir -p "$validation_dir/$bom/unit"
   cp -R dejavu/build/test-results/testDebugUnitTest/. "$validation_dir/$bom/unit/"
 
@@ -83,6 +85,7 @@ for bom in "${boms[@]}"; do
       :compose-experimental:connectedDebugAndroidTest \
       -PcomposeBomVersion="$bom"
     for module in demo compose-experimental; do
+      python3 validation/verify_test_results.py "$module/build/outputs/androidTest-results/connected"
       mkdir -p "$validation_dir/$bom/$module"
       cp -R "$module/build/outputs/androidTest-results/connected/." "$validation_dir/$bom/$module/"
     done

--- a/validation/consumer/README.md
+++ b/validation/consumer/README.md
@@ -1,0 +1,25 @@
+# Published artifact smoke tests
+
+This standalone build consumes Maven artifacts, without a project dependency or composite build.
+It checks the same packaged Android binary against supported Compose BOMs. Recompiling DejaVu
+against each BOM in the main suite cannot reveal every binary compatibility problem.
+
+Publish the candidate locally once using the release baseline, then run from the repository root:
+
+```bash
+./gradlew :dejavu:publishToMavenLocal --no-configuration-cache
+ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew -p validation/consumer \
+  jvmTest iosSimulatorArm64Test wasmJsBrowserTest -PdejavuVersion=0.5.0
+ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SERIAL=emulator-5554 \
+  ./gradlew -p validation/consumer connectedDebugAndroidTest \
+  -PdejavuVersion=0.5.0 -PcomposeBomVersion=2026.05.00
+```
+
+Repeat the Android command for the other version-catalog checkpoints and baseline. Run on the
+selected emulator only after the main instrumentation suite has finished. Preserve XML reports
+per BOM before the next run overwrites them. Supply your SDK location and current release version.
+
+The common smoke test suspends inside the public test helper, compares an exact recomposition
+count with an independent unkeyed `SideEffect`, and catches the expected over-budget failure.
+Android additionally instantiates the packaged test rule. The 1.12 baseline tests the new delegated
+`runWithoutImplicitWait` and `hasPendingWork` methods; older BOMs do not call APIs they lack.

--- a/validation/consumer/README.md
+++ b/validation/consumer/README.md
@@ -13,11 +13,19 @@ ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew -p validation/consumer \
 ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SERIAL=emulator-5554 \
   ./gradlew -p validation/consumer connectedDebugAndroidTest \
   -PdejavuVersion=0.5.0 -PcomposeBomVersion=2026.05.00
+python3 validation/verify_test_results.py \
+  validation/consumer/build/test-results/jvmTest \
+  validation/consumer/build/test-results/iosSimulatorArm64Test \
+  validation/consumer/build/test-results/wasmJsBrowserTest \
+  validation/consumer/build/outputs/androidTest-results/connected
 ```
 
 Repeat the Android command for the other version-catalog checkpoints and baseline. Run on the
 selected emulator only after the main instrumentation suite has finished. Preserve XML reports
 per BOM before the next run overwrites them. Supply your SDK location and current release version.
+Check the Android reports after every BOM run. A successful Gradle exit alone is insufficient:
+an emulator installation failure can leave no executed test reports. The verifier requires at
+least one actual test and no failures, errors, or skips in every supplied directory.
 
 The common smoke test suspends inside the public test helper, compares an exact recomposition
 count with an independent unkeyed `SideEffect`, and catches the expected over-budget failure.

--- a/validation/consumer/build.gradle.kts
+++ b/validation/consumer/build.gradle.kts
@@ -35,7 +35,9 @@ kotlin {
         jvmTest.dependencies { implementation(compose.desktop.currentOs) }
         androidInstrumentedTest.dependencies {
             implementation("androidx.compose.ui:ui-test-junit4")
-            implementation("androidx.test.ext:junit:1.3.0")
+            implementation(libs.androidx.junit)
+            // Match the release suite: older transitive Espresso cannot initialize on API 37.
+            implementation(libs.androidx.espresso.core)
         }
         if (androidBom >= "2026.08.00") {
             androidInstrumentedTest.get().kotlin.srcDir("src/android112Test/kotlin")

--- a/validation/consumer/build.gradle.kts
+++ b/validation/consumer/build.gradle.kts
@@ -63,3 +63,9 @@ dependencies {
     "debugImplementation"("androidx.compose.ui:ui-test-manifest")
 }
 composeCompiler { includeSourceInformation = true }
+
+if (providers.gradleProperty("rerunTests").isPresent) {
+    tasks.withType<org.gradle.api.tasks.testing.AbstractTestTask>().configureEach {
+        outputs.upToDateWhen { false }
+    }
+}

--- a/validation/consumer/build.gradle.kts
+++ b/validation/consumer/build.gradle.kts
@@ -1,0 +1,63 @@
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.compose.multiplatform)
+    alias(libs.plugins.android.library)
+}
+repositories { mavenLocal(); google(); mavenCentral() }
+val androidBom = providers.gradleProperty("composeBomVersion").orElse(libs.versions.composeBom).get()
+val releaseVersion = providers.gradleProperty("dejavuVersion").get()
+kotlin {
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    androidTarget {
+        instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)
+        compilations.all {
+            compileTaskProvider.configure {
+                compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+            }
+        }
+    }
+    jvm()
+    iosSimulatorArm64()
+    wasmJs { browser(); binaries.executable() }
+    sourceSets {
+        commonMain.dependencies { implementation(compose.ui) }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+            implementation("me.mmckenna.dejavu:dejavu:$releaseVersion")
+            implementation(compose.foundation)
+            @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+            implementation(compose.uiTest)
+        }
+        jvmTest.dependencies { implementation(compose.desktop.currentOs) }
+        androidInstrumentedTest.dependencies {
+            implementation("androidx.compose.ui:ui-test-junit4")
+            implementation("androidx.test.ext:junit:1.3.0")
+        }
+        if (androidBom >= "2026.08.00") {
+            androidInstrumentedTest.get().kotlin.srcDir("src/android112Test/kotlin")
+        }
+    }
+}
+android {
+    namespace = "dejavu.consumer"
+    compileSdk = 37
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    defaultConfig {
+        minSdk = 24
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+}
+dependencies {
+    val bom = enforcedPlatform("androidx.compose:compose-bom:$androidBom")
+    "androidMainImplementation"(bom)
+    "androidInstrumentedTestImplementation"(bom)
+    "debugImplementation"("androidx.compose.ui:ui-test-manifest")
+}
+composeCompiler { includeSourceInformation = true }

--- a/validation/consumer/gradle.properties
+++ b/validation/consumer/gradle.properties
@@ -1,0 +1,4 @@
+android.useAndroidX=true
+android.builtInKotlin=false
+android.newDsl=false
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m -Dfile.encoding=UTF-8

--- a/validation/consumer/settings.gradle.kts
+++ b/validation/consumer/settings.gradle.kts
@@ -1,0 +1,5 @@
+pluginManagement { repositories { google(); mavenCentral(); gradlePluginPortal() } }
+dependencyResolutionManagement {
+    versionCatalogs { create("libs") { from(files("../../gradle/libs.versions.toml")) } }
+}
+rootProject.name = "dejavu-release-consumer"

--- a/validation/consumer/src/android112Test/kotlin/PublishedNewRuleApiTest.kt
+++ b/validation/consumer/src/android112Test/kotlin/PublishedNewRuleApiTest.kt
@@ -1,0 +1,26 @@
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.onNodeWithTag
+import dejavu.assertStable
+import dejavu.createRecompositionTrackingRule
+import dejavu.resetRecompositionCounts
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertFalse
+
+class PublishedNewRuleApiTest {
+    @get:Rule val rule = createRecompositionTrackingRule()
+    @Test fun newRuleMethodsDelegateToCompose112() {
+        rule.setContent { BasicText("Stable", Modifier.testTag("stable")) }
+        rule.waitForIdle()
+        rule.resetRecompositionCounts()
+        rule.runOnUiThread {
+            rule.runWithoutImplicitWait {
+                rule.onNodeWithTag("stable").assertTextEquals("Stable").assertStable()
+                assertFalse(rule.hasPendingWork())
+            }
+        }
+    }
+}

--- a/validation/consumer/src/androidInstrumentedTest/kotlin/PublishedAndroidRuleTest.kt
+++ b/validation/consumer/src/androidInstrumentedTest/kotlin/PublishedAndroidRuleTest.kt
@@ -1,0 +1,23 @@
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.onNodeWithTag
+import dejavu.assertRecompositions
+import dejavu.createRecompositionTrackingRule
+import dejavu.resetRecompositionCounts
+import org.junit.Rule
+import org.junit.Test
+
+class PublishedAndroidRuleTest {
+    @get:Rule val rule = createRecompositionTrackingRule()
+    @Test fun baselineBuiltRuleWorksWithTheSelectedRuntime() {
+        val value = mutableIntStateOf(0)
+        rule.setContent { BasicText("${value.intValue}", Modifier.testTag("value")) }
+        rule.waitForIdle()
+        rule.resetRecompositionCounts()
+        rule.runOnIdle { value.intValue++ }
+        rule.waitForIdle()
+        rule.onNodeWithTag("value").assertRecompositions(exactly = 1)
+    }
+}

--- a/validation/consumer/src/androidInstrumentedTest/kotlin/PublishedAndroidRuleTest.kt
+++ b/validation/consumer/src/androidInstrumentedTest/kotlin/PublishedAndroidRuleTest.kt
@@ -1,4 +1,6 @@
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -9,15 +11,26 @@ import dejavu.resetRecompositionCounts
 import org.junit.Rule
 import org.junit.Test
 
+private var ruleCompositions = 0
+
 class PublishedAndroidRuleTest {
     @get:Rule val rule = createRecompositionTrackingRule()
     @Test fun baselineBuiltRuleWorksWithTheSelectedRuntime() {
         val value = mutableIntStateOf(0)
-        rule.setContent { BasicText("${value.intValue}", Modifier.testTag("value")) }
+        ruleCompositions = 0
+        rule.setContent { ConsumerAndroidValue(value.intValue) }
         rule.waitForIdle()
+        val baseline = ruleCompositions
         rule.resetRecompositionCounts()
         rule.runOnIdle { value.intValue++ }
         rule.waitForIdle()
-        rule.onNodeWithTag("value").assertRecompositions(exactly = 1)
+        kotlin.test.assertEquals(1, ruleCompositions - baseline)
+        rule.onNodeWithTag("value").assertRecompositions(exactly = ruleCompositions - baseline)
     }
+}
+
+@Composable
+private fun ConsumerAndroidValue(value: Int) {
+    SideEffect { ruleCompositions++ }
+    BasicText("$value", Modifier.testTag("value"))
 }

--- a/validation/consumer/src/commonTest/kotlin/PublishedArtifactTest.kt
+++ b/validation/consumer/src/commonTest/kotlin/PublishedArtifactTest.kt
@@ -1,0 +1,44 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.onNodeWithTag
+import dejavu.assertRecompositions
+import dejavu.assertStable
+import dejavu.resetRecompositionCounts
+import dejavu.runRecompositionTrackingUiTest
+import dejavu.setTrackedContent
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+private var compositions = 0
+
+class PublishedArtifactTest {
+    @Test
+    fun publishedArtifactTracksAcrossSuspension() = runRecompositionTrackingUiTest {
+        val value = mutableIntStateOf(0)
+        compositions = 0
+        setTrackedContent { PublishedValue(value.intValue) }
+        waitForIdle()
+        val baseline = compositions
+        resetRecompositionCounts()
+        yield()
+        runOnIdle { value.intValue++ }
+        waitForIdle()
+        assertEquals(1, compositions - baseline)
+        onNodeWithTag("published_value").assertRecompositions(exactly = compositions - baseline)
+        assertFailsWith<AssertionError> { onNodeWithTag("published_value").assertStable() }
+    }
+}
+
+@Composable
+private fun PublishedValue(value: Int) {
+    SideEffect { compositions++ }
+    BasicText("Value: $value", Modifier.testTag("published_value"))
+}

--- a/validation/verify_maven_publication.py
+++ b/validation/verify_maven_publication.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Verify every public DejaVu target artifact and its Maven coordinates."""
 
+import json
 import re
 import sys
 from urllib.error import HTTPError, URLError
@@ -33,8 +34,19 @@ def verify(version: str) -> bool:
                                 for field in ("groupId", "artifactId", "version"))
             if coordinates != (GROUP, artifact, version):
                 raise ValueError(f"Unexpected Maven coordinates: {coordinates}")
-            print(f"PASS {artifact}:{version} ({extension} and POM)")
-        except (HTTPError, URLError, ValueError, ElementTree.ParseError) as error:
+            with urlopen(f"{prefix}.module", timeout=30) as response:
+                metadata = json.load(response)
+            component = metadata["component"]
+            module_coordinates = tuple(component.get(field) for field in ("group", "module", "version"))
+            # KMP target metadata identifies the root component that owns its variants.
+            if module_coordinates != (GROUP, "dejavu", version):
+                raise ValueError(f"Unexpected Gradle module coordinates: {module_coordinates}")
+            files = {entry["url"] for variant in metadata["variants"]
+                     for entry in variant.get("files", [])}
+            if f"{artifact}-{version}.{extension}" not in files:
+                raise ValueError("Gradle metadata does not reference the target artifact")
+            print(f"PASS {artifact}:{version} ({extension}, POM, and Gradle module metadata)")
+        except (HTTPError, URLError, TimeoutError, KeyError, ValueError, ElementTree.ParseError) as error:
             print(f"FAIL {artifact}:{version}: {error}")
             passed = False
     return passed

--- a/validation/verify_maven_publication.py
+++ b/validation/verify_maven_publication.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Verify every public DejaVu target artifact and its Maven coordinates."""
+
+import re
+import sys
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+from xml.etree import ElementTree
+
+PUBLICATIONS = {
+    "dejavu": "jar",
+    "dejavu-android": "aar",
+    "dejavu-jvm": "jar",
+    "dejavu-iosarm64": "klib",
+    "dejavu-iossimulatorarm64": "klib",
+    "dejavu-wasm-js": "klib",
+}
+GROUP = "me.mmckenna.dejavu"
+BASE = "https://repo.maven.apache.org/maven2/me/mmckenna/dejavu"
+
+
+def verify(version: str) -> bool:
+    passed = True
+    namespace = {"m": "http://maven.apache.org/POM/4.0.0"}
+    for artifact, extension in PUBLICATIONS.items():
+        prefix = f"{BASE}/{artifact}/{version}/{artifact}-{version}"
+        try:
+            with urlopen(Request(f"{prefix}.{extension}", method="HEAD"), timeout=30):
+                pass
+            with urlopen(f"{prefix}.pom", timeout=30) as response:
+                pom = ElementTree.fromstring(response.read())
+            coordinates = tuple(pom.findtext(f"m:{field}", namespaces=namespace)
+                                for field in ("groupId", "artifactId", "version"))
+            if coordinates != (GROUP, artifact, version):
+                raise ValueError(f"Unexpected Maven coordinates: {coordinates}")
+            print(f"PASS {artifact}:{version} ({extension} and POM)")
+        except (HTTPError, URLError, ValueError, ElementTree.ParseError) as error:
+            print(f"FAIL {artifact}:{version}: {error}")
+            passed = False
+    return passed
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or not re.fullmatch(r"\d+\.\d+\.\d+", sys.argv[1]):
+        sys.exit("Usage: verify_maven_publication.py X.Y.Z")
+    sys.exit(0 if verify(sys.argv[1]) else 1)

--- a/validation/verify_test_results.py
+++ b/validation/verify_test_results.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Require executed JUnit tests, with no failures/errors/skips, in every report directory."""
+
+import sys
+from pathlib import Path
+from xml.etree import ElementTree
+
+
+def verify(directory: Path) -> bool:
+    reports = sorted(directory.rglob("TEST-*.xml"))
+    counts = {"tests": 0, "failures": 0, "errors": 0, "skipped": 0}
+    for report in reports:
+        root = ElementTree.parse(report).getroot()
+        counts["tests"] += sum(1 for _ in root.iter("testcase"))
+        for kind in ("failure", "error", "skipped"):
+            key = {"failure": "failures", "error": "errors", "skipped": "skipped"}[kind]
+            counts[key] += sum(1 for _ in root.iter(kind))
+    passed = counts["tests"] > 0 and not any(counts[k] for k in ("failures", "errors", "skipped"))
+    print(f"{'PASS' if passed else 'FAIL'} {directory}: {counts}")
+    return passed
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit("Usage: verify_test_results.py REPORT_DIRECTORY [REPORT_DIRECTORY ...]")
+    results = [verify(Path(argument)) for argument in sys.argv[1:]]
+    sys.exit(0 if all(results) else 1)


### PR DESCRIPTION
DejaVu 0.5.0 targets stable Compose Multiplatform 1.12.0 and Android BOM 2026.08.00 while retaining the Android Compose 1.11 floor. This follows the 0.4.0 release for Compose 1.11 and keeps DejaVu versions independent of Compose versions.

Six new regressions cover keyed SideEffect, shrinking effect/remember keys, frame assertions without implicit waits, and nested movable content under LinkBuffer. The keyed-effect fixture deliberately recomposes four times while its keyed callback stays quiet; unkeyed SideEffect remains the oracle, and DejaVu must reject an incorrect zero budget. Version-specific Styles adapters retain identical test behavior across the experimental API change. Wasm tests use the executable bundling required by Compose 1.12.

The Android rule adds delegated hasPendingWork and runWithoutImplicitWait methods. Those methods require Compose 1.12. The published AAR requires compile SDK 37; retaining an older Android Compose line requires an enforced BOM. A standalone Maven consumer checks the packaged binary against older runtimes, alongside the source compatibility matrix.

Supersedes #134 (the grouped Compose update replacing #127 and #124) and #131 (AGP). Gradle 9.6.0 already meets AGP 9.4.0's requirement; unrelated dependency updates remain separate.

The packaged consumer exposed mixed-harness integration failures. Android activity tables now remain combined with explicit helper tables, helper cleanup restores previously active tracing, and the Android rule enables tracking before activity launch. Regressions failed before these fixes and now verify the rule/helper/rule sequence and the first real update after tracking was disabled, using independent SideEffect counters and expected budget failures.

Validation passed: 229 core tests and 26 experimental tests on each of JVM, iOS simulator, and Wasm; 225 demo and 27 unit tests at each Android BOM; 20 experimental tests at the older BOMs and 26 at the 1.12 baseline. All six Maven publications built locally. Packaged consumers passed one test on each KMP target and 2 / 2 / 3 Android tests at the supported BOMs. There were no final failures, errors, or skips.

Production implementation: `3c949ab335c3b822ba1308201f8b8c7ab8976d80`; final Android test fixture: `fa817151eb3d5d49574ffaa7f90b3203b4ff2a18`. The manual disabled-runtime regression uses a single test environment and checks the displayed value plus independent and tracked counts. The [validation record](https://github.com/mttmcknn/dejavu/blob/codex/compose-112-release/docs/releases/0.5.0.md) explains the completed phases and preserved reports. Older Android source checkpoints use API 37 with 16 KB pages; the 1.12 source checkpoint and packaged consumers use API 36 with 4 KB pages. Historical API 26/31 device jobs were not repeated. Passing local checks replace repeated hosted CI matrices under the approved release policy.

The release checklist now rejects empty test reports and verifies all public Maven binaries, POMs, and Gradle variant metadata before announcements. DejaVu 0.4.0 is already publicly released; this is the sequential Compose 1.12 follow-up.

Release notes, validation progress, and social drafts are tracked in the shared document: https://docs.google.com/document/d/1nfIzsfxz0ze_rTy5EKO0vG8TO_JyXDdricco7q5oyfY/edit
