### PR TITLE
Prepare 0.6.0 development and record 0.5.0 publication

### DIFF
--- a/dejavu/build.gradle.kts
+++ b/dejavu/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "me.mmckenna.dejavu"
-version = "0.5.0"
+version = "0.6.0-SNAPSHOT"
 
 kotlin {
   explicitApi()

--- a/docs/releases/0.5.0.md
+++ b/docs/releases/0.5.0.md
@@ -118,7 +118,14 @@ and its Espresso dependency is aligned with the main suite for API 37.
 - [GitHub release](https://github.com/mttmcknn/dejavu/releases/tag/v0.5.0)
 - [Shared tracker and social drafts](https://docs.google.com/document/d/1nfIzsfxz0ze_rTy5EKO0vG8TO_JyXDdricco7q5oyfY/edit)
 
-Maven Central availability is checked separately after publication.
+All six target binaries, POM coordinates, and Gradle module metadata were verified publicly on
+Maven Central on September 9, 2026 at 17:22 UTC. The GitHub release was published at 17:23 UTC.
+The [publication workflow](https://github.com/mttmcknn/dejavu/actions/runs/34379180267) had completed
+at 16:53 UTC while Central was still publishing; the GitHub release remained a draft until
+the public checks passed. Social copy remains a draft in the shared tracker; no posts were sent.
+The [documentation deployment](https://github.com/mttmcknn/dejavu/actions/runs/34382595061)
+passed; the [0.5.0 documentation](https://dejavu.mmckenna.me/0.5.0/) is public and owns the
+`latest` documentation alias.
 
 ## Mixed harness regression
 


### PR DESCRIPTION
DejaVu 0.5.0 is publicly released for Compose 1.12. Record its verified Maven Central and GitHub publication, then prepare the next development cycle with version `0.6.0-SNAPSHOT`. The immutable `v0.5.0` tag remains the release, and stable dependency examples remain on 0.5.0.

Validation: `verifyComposeBomConfiguration` and `git diff --check` passed. No runtime source changes.
