### PR TITLE
Refresh release docs and prevent stale website versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,14 +2,14 @@
   "name": "dejavu",
   "owner": {
     "name": "Matt McKenna",
-    "url": "https://github.com/himattm"
+    "url": "https://github.com/mttmcknn"
   },
   "plugins": [
     {
       "name": "dejavu",
       "source": "./",
       "description": "AI agent skills for authoring Compose UI recomposition tests with Dejavu and running a closed-loop perf optimization workflow.",
-      "version": "0.1.0"
+      "version": "0.2.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "dejavu",
   "description": "AI agent skills for authoring Compose UI recomposition tests with the Dejavu library and running a closed-loop perf optimization workflow.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Matt McKenna",
-    "url": "https://github.com/himattm"
+    "url": "https://github.com/mttmcknn"
   },
   "homepage": "https://dejavu.mmckenna.me",
-  "repository": "https://github.com/himattm/dejavu",
+  "repository": "https://github.com/mttmcknn/dejavu",
   "license": "Apache-2.0",
   "keywords": [
     "compose",

--- a/.claude/skills/dejavu-onboarding/SKILL.md
+++ b/.claude/skills/dejavu-onboarding/SKILL.md
@@ -88,8 +88,12 @@ kotlin {
 ```
 
 Use the latest version from Maven Central (the README badge has the current
-number) compatible with the project's Compose version. DejaVu 0.5.x requires Compose 1.11;
-Compose 1.10 projects should stay on 0.3.1. Don't downgrade a compatible newer release.
+number) compatible with the project's Compose version. DejaVu 0.5.x builds against Compose
+Multiplatform 1.12.0 and requires Android compile SDK 37 and min SDK 24. Android Compose 1.11
+is supported only with its BOM enforced in both app and instrumentation dependencies.
+Use 0.4.0 for Compose Multiplatform 1.11 / compile SDK 36, and 0.3.1 for Compose 1.10.
+Follow the complete setup in `docs/getting-started.md`, including the plain rule's debug test
+manifest dependency. Don't downgrade a compatible newer release.
 
 ### 4. Pick a target composable for the first test
 
@@ -200,7 +204,7 @@ Filter logcat with tag `Dejavu`. See `docs/use-cases.md` "Stream Composition Sta
   compiler plugin if it isn't already configured.
 - **Wasm test completion** — return `runRecompositionTrackingUiTest` directly from the test.
   Put diagnostic assertions inside its body so the runner awaits their asynchronous result.
-  DejaVu 0.5.0 restores lazy-grid and diagnostic-message coverage on iOS/Wasm.
+  DejaVu 0.4.0 restores lazy-grid and diagnostic-message coverage on iOS/Wasm.
 
 ## Wrap-up
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,8 +20,11 @@ What actually happened. Include assertion output if applicable.
 
 ## Environment
 - Dejavu version:
-- Compose version:
-- Android API level:
+- Compose Multiplatform version and/or Android BOM:
+- Kotlin version:
+- Target (Android, JVM, iOS, Wasm):
+- Test harness (Android rule or KMP helper):
+- Android compile SDK and device API level (if applicable):
 - Device/Emulator:
 
 ## Additional Context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,10 @@
-## Description
-<!-- Describe your changes -->
+## Change
+<!-- Describe the concrete problem and resulting behavior. -->
 
-## Checklist
-- [ ] JVM unit tests pass (`./gradlew :dejavu:testDebugUnitTest`)
-- [ ] Lint passes (`./gradlew :dejavu:lintDebug`)
-- [ ] API compatibility checked (`./gradlew apiCheck`)
-- [ ] Instrumented tests pass (if applicable)
-- [ ] New public API has KDoc
+## Validation
+<!-- List commands, source revision, platforms, actual test counts, and any exclusions.
+     Equivalent local results can replace hosted CI constrained by budget. -->
+
+- [ ] Affected Compose UI tests pass for runtime changes; intentional inefficient fixtures remain intact.
+- [ ] API compatibility and lint checked where applicable; new public API has KDoc.
+- [ ] Docs-only changes pass the strict site build and link checks in CONTRIBUTING.md.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
     tags: ['v*']
   workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Optional current stable X.Y.Z to refresh from main, without publishing artifacts'
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: write
@@ -38,23 +44,50 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Update docs version references
+      - name: Select and validate documentation version
+        id: version
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
         run: |
-          VERSION=$(grep '^version = ' dejavu/build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
-          sed -i "s/dejavu:[0-9]\+\.[0-9]\+\.[0-9]\+/dejavu:$VERSION/g" docs/*.md
+          DOCS_VERSION=$(python3 validation/docs.py version --ref "$GITHUB_REF" --release "$RELEASE_VERSION")
+          echo "DEJAVU_DOCS_VERSION=$DOCS_VERSION" >> "$GITHUB_ENV"
+          if [[ "$DOCS_VERSION" == *-SNAPSHOT ]]; then
+            echo "source_ref=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+            echo "alias=snapshot" >> "$GITHUB_OUTPUT"
+          else
+            echo "source_ref=v$DOCS_VERSION" >> "$GITHUB_OUTPUT"
+            echo "alias=latest" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Generate API documentation
-        run: ./gradlew -q --console=plain :dejavu:dokkaGeneratePublicationHtml
-
-      - name: Deploy snapshot (main branch)
-        if: github.ref == 'refs/heads/main'
+        env:
+          SOURCE_REF: ${{ steps.version.outputs.source_ref }}
         run: |
-          VERSION=$(grep '^version = ' dejavu/build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
-          mike deploy --update-aliases --push "${VERSION%-SNAPSHOT}-SNAPSHOT" snapshot
+          ./gradlew -q --console=plain :dejavu:dokkaGeneratePublicationHtml \
+            -PdocsVersion="$DEJAVU_DOCS_VERSION" -PdocsSourceRef="$SOURCE_REF"
 
-      - name: Deploy release (tag)
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Validate documentation
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
-          mike deploy --update-aliases --push "$VERSION" latest
-          mike set-default --push latest
+          python3 validation/docs.py repair-api docs/api
+          mkdocs build --strict
+          python3 validation/docs.py verify site
+
+      - name: Deploy documentation
+        env:
+          DOCS_ALIAS: ${{ steps.version.outputs.alias }}
+        run: |
+          mike deploy --update-aliases --push "$DEJAVU_DOCS_VERSION" "$DOCS_ALIAS"
+          if [[ "$DOCS_ALIAS" == latest ]]; then
+            mike set-default --push latest
+          fi
+
+      - name: Refresh unversioned guide redirects
+        run: |
+          git worktree add build/docs-pages gh-pages
+          python3 validation/docs.py redirects build/docs-pages
+          git -C build/docs-pages add getting-started examples use-cases how-it-works error-messages causality-analysis api-reference api
+          if ! git -C build/docs-pages diff --cached --quiet; then
+            git -C build/docs-pages commit -m "Point unversioned guides to latest documentation"
+            git -C build/docs-pages push origin gh-pages
+          fi
+          git worktree remove build/docs-pages

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ local.properties
 .kotlin/
 site/
 docs/api/
+__pycache__/
 blog/
 iosApp/*.xcodeproj

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `dejavu-test-writer` — authors Compose UI recomposition tests using Dejavu's APIs.
   - `dejavu-error-triage` — one-shot diagnosis of a single `UnexpectedRecompositionsError` block.
   - `dejavu-perf-loop` — closed-loop optimization using Dejavu as the validator.
-- Packaged the same skills as a Claude Code plugin (`dejavu`) installable via `/plugin marketplace add himattm/dejavu` + `/plugin install dejavu@dejavu`. Plugin manifest at `.claude-plugin/plugin.json`, marketplace at `.claude-plugin/marketplace.json`, with `skills/` symlinked into `.claude/skills/` for a single source of truth.
+- Packaged the same skills as a Claude Code plugin (`dejavu`) installable via `/plugin marketplace add mttmcknn/dejavu` + `/plugin install dejavu@dejavu`. Plugin manifest at `.claude-plugin/plugin.json`, marketplace at `.claude-plugin/marketplace.json`, with `skills/` symlinked into `.claude/skills/` for a single source of truth.
 - New `compose-experimental` module (a staging area for experimental-API recomposition coverage) with tests for Compose 1.11's new APIs, running on JVM, iOS, Wasm, and Android instrumented: experimental `Grid`, experimental `FlexBox`, the experimental LinkBuffer composer runtime path (`ComposeRuntimeFlags.isLinkBufferComposerEnabled`), `movableContentOf`, `derivedMediaQuery`/`mediaQuery` (adaptive breakpoints), and the Styles API (`androidx.compose.foundation.style`).
 - Public `ComposeUiTest.resetRecompositionCounts()` for KMP recomposition tests — resets recomposition counts mid-test while preserving composition history.
 - A Coil-style `test.sh` release check and `RELEASING.md` checklist that pin one Compose

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Minimum verification after any code change:
 
 Separate Gradle module (`:compose-experimental`) that stages recomposition tests for experimental /
 newest-Compose APIs before they graduate into the core accuracy suite. KMP targets use the pinned
-Compose Multiplatform baseline; Android builds and runs this module at every supported Compose 1.11
+Compose Multiplatform baseline; Android builds and runs this module at every supported Compose 1.11–1.12
 BOM checkpoint. Convention: when an API graduates to stable and the `:dejavu` BOM floor includes
 it, promote its test into `dejavu/src/commonTest` and delete it here. See
 `compose-experimental/README.md`.
@@ -67,7 +67,11 @@ Always run with `-q --console=plain`.
 For release readiness, start a clean emulator, set `ANDROID_SERIAL`, and run
 `./test.sh --all-boms`. This enforces every supported Android BOM and runs both UI suites in
 addition to the JVM, iOS, Wasm, API, lint, and demo build checks. Compose 1.10 consumers remain on
-Dejavu 0.3.1; Dejavu 0.4.x supports Compose 1.11 BOM 2026.05.00 through 2026.06.01.
+Dejavu 0.3.1; 0.4.0 retains the Compose Multiplatform 1.11 / compile SDK 36 baseline. DejaVu 0.5.x
+builds against Compose Multiplatform 1.12.0 and supports Android BOM 2026.05.00 through 2026.08.00.
+Android consumers require compile SDK 37 and must enforce the BOM to retain an older Compose line.
+For documentation-only edits, run the documentation checks in CONTRIBUTING.md; UI suites are
+required for runtime changes, not prose or website changes.
 
 ## Bundled Claude skills
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,62 +1,90 @@
 # Contributing to Dejavu
 
-Thank you for your interest in contributing to Dejavu! This guide will help you get started.
+Dejavu validates recomposition behavior on Android, JVM desktop, iOS, and Wasm. Some sample
+composables intentionally recompose too often. Preserve those fixtures: a correct test proves
+that Dejavu matches independent unkeyed `SideEffect` counters and rejects an incorrect budget.
+A keyed `SideEffect` does not count every recomposition.
 
-## Getting Started
-
-1. **Clone the repository**
-   ```bash
-   git clone https://github.com/himattm/dejavu.git
-   cd dejavu
-   ```
-
-2. **Open in Android Studio** -- use the latest stable version of Android Studio with Kotlin 2.0+ support.
-
-3. **Sync Gradle** -- Android Studio will prompt you to sync on first open. You can also sync manually via `File > Sync Project with Gradle Files`.
-
-## Running Tests
-
-### JVM Unit Tests
+## Development setup
 
 ```bash
-./gradlew :dejavu:testDebugUnitTest
+git clone https://github.com/mttmcknn/dejavu.git
+cd dejavu
 ```
 
-These run on your local machine without an emulator and cover core tracker logic and tracer unit tests.
+Use the Gradle wrapper and JDK 17 or later. The current build pins Kotlin 2.4.0, AGP 9.4.0,
+Compose Multiplatform 1.12.0, and Android compile SDK 37. Install Android SDK platform 37 and
+accept its licenses. Android Studio must support the pinned AGP version; the Gradle wrapper is
+the command-line source of truth. Android test devices must run API 24 or later.
 
-### Instrumented Tests
+JVM tests need a desktop environment. Wasm browser tests need Chrome. iOS tests require macOS,
+Xcode, and an available arm64 simulator. See the [release validation record](docs/releases/0.5.0.md)
+for the exact environments used for the current release; minimum device support is not a claim
+that every supported OS was freshly tested.
+
+## Running tests
+
+Run targeted checks during development, then broaden to affected platforms:
 
 ```bash
-./gradlew :demo:connectedDebugAndroidTest
+# Android unit tests, without a device
+./gradlew -q --console=plain :dejavu:testDebugUnitTest
+
+# Actual Compose UI tests on each non-Android platform
+./gradlew -q --console=plain :dejavu:jvmTest :compose-experimental:jvmTest
+./gradlew -q --console=plain :dejavu:iosSimulatorArm64Test :compose-experimental:iosSimulatorArm64Test
+./gradlew -q --console=plain :dejavu:wasmJsBrowserTest :compose-experimental:wasmJsBrowserTest
+
+# Android UI tests on an explicitly selected emulator
+ANDROID_SERIAL=emulator-5554 ./gradlew -q --console=plain \
+  :demo:connectedDebugAndroidTest :compose-experimental:connectedDebugAndroidTest
+
+./gradlew -q --console=plain apiCheck :dejavu:lintDebug
 ```
 
-These require a running Android emulator or connected device (API 21+). The instrumented test suite covers UI tracking, assertion APIs, stress tests, and error output validation.
+For release readiness, use a clean emulator and `ANDROID_SERIAL=emulator-5554 ./test.sh --all-boms`.
+The script reads the supported BOMs from `gradle/libs.versions.toml`, forces fresh tests, saves
+reports, and rejects missing, failed, or skipped tests. Runtime changes need real UI tests;
+Android unit tests alone cannot verify recomposition accuracy. For new Compose APIs, see
+[compose-experimental](compose-experimental/README.md).
 
-## Code Style
+Hosted CI may be limited by budget. Equivalent passing local checks, with source revision,
+commands, platform details, counts, and exclusions recorded, can satisfy the release gate.
+Reproduced product failures still need fixes. Packaged release verification is described in
+[RELEASING.md](RELEASING.md) and the [standalone consumer guide](validation/consumer/README.md).
 
-- Follow standard [Kotlin coding conventions](https://kotlinlang.org/docs/coding-conventions.html).
-- No specific formatter is enforced yet. Keep your code consistent with the existing style in the file you are editing.
-- Use KDoc for all public API surfaces.
+## Documentation changes
 
-## Submitting PRs
+User guides live in `docs/`; the API site is generated from source and `dejavu/Module.md`.
+Use the pinned tools in a virtual environment:
 
-1. **Branch from `main`** -- this is the active development branch.
-   ```bash
-   git checkout main
-   git pull origin main
-   git checkout -b your-feature-branch
-   ```
+```bash
+python3 -m venv /tmp/dejavu-docs-env
+/tmp/dejavu-docs-env/bin/pip install -r .github/workflows/mkdocs-requirements.txt
+./gradlew -q --console=plain :dejavu:dokkaGeneratePublicationHtml
+python3 validation/docs.py repair-api docs/api
+/tmp/dejavu-docs-env/bin/mkdocs build --strict
+python3 validation/docs.py verify site
+```
 
-2. **Write tests** -- every new feature or bug fix should include tests. Use `createRecompositionTrackingRule<Activity>()` for instrumented tests.
+Update `extra.dejavu_release` in `mkdocs.yml`, dependency examples, compatibility guidance, and
+release links together when publishing a new version. Historical release records retain their
+original versions. `snapshot` is development documentation; `latest` is the stable release.
+The release checklist covers docs-only corrections and redirects from old unversioned URLs.
+Prose-only edits require a strict documentation build and link checks, not the full UI matrix.
 
-3. **Ensure all tests pass** -- run both JVM and instrumented tests before submitting.
+## Pull requests and API changes
 
-4. **Describe your changes clearly** -- explain what the PR does, why it is needed, and how you tested it.
+Branch from `main`. Explain the concrete behavior change and include the checks you ran and
+any limitations. Add regressions for fixes and new behavior; preserve intentional inefficient
+fixtures. Follow existing Kotlin style and add KDoc to new public APIs.
 
-## API Changes
+When changing the public API, run `./gradlew -q --console=plain apiDump`, review the generated
+changes, commit the API files, and run `apiCheck`. Do not accept an API diff solely to make a
+failing check green.
 
-If your change modifies the public API surface:
-
-1. Run `./gradlew apiDump` to regenerate the API definition file.
-2. Commit the updated API file alongside your code changes.
-3. CI will run `./gradlew apiCheck` to verify API compatibility.
+Use the [bug template](https://github.com/mttmcknn/dejavu/issues/new?template=bug_report.md) for
+reproducible problems and the [feature template](https://github.com/mttmcknn/dejavu/issues/new?template=feature_request.md)
+for proposals. Include the DejaVu version, Compose BOM or Multiplatform version, platform, and
+an independent expected recomposition count. Follow [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+and [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 *Wait... didn't we just compose this?*
 
-[![CI](https://github.com/himattm/dejavu/actions/workflows/ci.yml/badge.svg)](https://github.com/himattm/dejavu/actions/workflows/ci.yml)
+[![CI](https://github.com/mttmcknn/dejavu/actions/workflows/ci.yml/badge.svg)](https://github.com/mttmcknn/dejavu/actions/workflows/ci.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/me.mmckenna.dejavu/dejavu)](https://central.sonatype.com/artifact/me.mmckenna.dejavu/dejavu)
 [![Compose](https://img.shields.io/badge/Compose-1.11–1.12-4285F4?logo=jetpackcompose&logoColor=white)](https://developer.android.com/develop/ui/compose)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -41,6 +41,10 @@ Dejavu is a test-only library that turns recomposition behavior into assertions.
 
 ### 1. Add dependency
 
+DejaVu 0.5.0 requires Android **compile SDK 37** and **min SDK 24**. The release uses
+Compose Multiplatform 1.12.0; Android Compose 1.11 remains supported with an enforced BOM.
+See [Compatibility](#compatibility) before adding the dependency to an older Compose project.
+
 ```kotlin
 // app/build.gradle.kts
 dependencies {
@@ -67,7 +71,10 @@ fun incrementCounter_onlyValueRecomposes() {
 }
 ```
 
-`createRecompositionTrackingRule` wraps `createAndroidComposeRule` and resets counts before each test. For `createComposeRule()` or other rule types, see [Examples](https://dejavu.mmckenna.me/examples/).
+This test assumes the counter screen is already set. Use `createRecompositionTrackingRule<YourActivity>()`
+to launch an activity that sets that screen, or call `composeTestRule.setContent { YourScreen() }`
+when using the plain rule. The [Getting Started guide](https://dejavu.mmckenna.me/latest/getting-started/)
+includes a complete example.
 
 ## What a Failure Looks Like
 
@@ -90,7 +97,7 @@ dejavu.UnexpectedRecompositionsError: Recomposition assertion failed for testTag
     Parameter/parent change detected (dirty bits set)
 ```
 
-See [Error Messages Guide](https://dejavu.mmckenna.me/error-messages/) for how to read and act on each section.
+See [Error Messages Guide](https://dejavu.mmckenna.me/latest/error-messages/) for how to read and act on each section.
 
 ## Claude Code Skills (for AI Agents)
 
@@ -104,7 +111,7 @@ Dejavu ships four Claude Code skills that teach AI agents how to use it:
 Install them globally in Claude Code so they're available in any project:
 
 ```
-/plugin marketplace add himattm/dejavu
+/plugin marketplace add mttmcknn/dejavu
 /plugin install dejavu@dejavu
 ```
 
@@ -126,7 +133,7 @@ For Claude Code users, the bundled `dejavu-test-writer` and `dejavu-perf-loop` s
 
 When AI agents or automated tooling modify your codebase, they can introduce subtle changes to recomposition behavior without touching any visible UI. Dejavu tests act as guardrails — if an agent's changes cause a composable to recompose more than expected, the test fails before the change is merged. You get the speed of automated refactoring with the confidence that recomposition behavior is preserved.
 
-See the full [Use Cases](https://dejavu.mmckenna.me/use-cases/) guide for examples.
+See the full [Use Cases](https://dejavu.mmckenna.me/latest/use-cases/) guide for examples.
 
 ## API Reference
 
@@ -184,7 +191,8 @@ Dejavu hooks into the Compose runtime's `CompositionTracer` API (available since
 4. **Tracks causality** — `Snapshot.registerApplyObserver` detects state changes; dirty bits detect parameter-driven recompositions
 5. **Reports on failure** — assembles source location, timeline, tracked composables, and causality into a structured error
 
-All tracking runs in the app process on the main thread, directly accessible to instrumented tests.
+On Android, tracking runs in the app process and is accessible to instrumented tests. JVM, iOS,
+and Wasm tests use the shared tracer through `runRecompositionTrackingUiTest`.
 
 ## Compatibility
 
@@ -267,15 +275,16 @@ Compose 1.12. These methods require 1.12; the existing rule API remains covered 
 ## Known Limitations
 
 - **Off-screen lazy items** — `LazyColumn`/`LazyRow` only compose items that are visible. Items that haven't been composed don't exist in the composition tree, so Dejavu has nothing to track. Scroll them into view before asserting.
+- **Non-Android instance diagnostics** — unresolved tags can share a function-level count when multiple instances use the same composable. Android has the most complete per-instance diagnostics.
 - **Activity-owned Recomposer clock** — `createAndroidComposeRule` uses the Activity's real `Recomposer`, not a test-controlled one. This means `mainClock.advanceTimeBy()` can't drive infinite animations forward. Use `createComposeRule` (without an Activity) if you need a controllable clock.
 - **Parameter change tracking precision** — parameter diffs use `Group.parameters` from the Compose tooling data API, which was designed for Layout Inspector rather than programmatic diffing. Parameter names may be unavailable, and values are compared via `hashCode`/`toString`, so custom types without meaningful `toString` show opaque values.
 
 ## Further Reading
 
-- [Use Cases](https://dejavu.mmckenna.me/use-cases/) — locking in UI efficiency, AI agent guardrails, and CI enforcement
-- [Examples](https://dejavu.mmckenna.me/examples/) — test patterns for common scenarios
-- [Error Messages Guide](https://dejavu.mmckenna.me/error-messages/) — how to read and act on failure output
-- [Causality Analysis](https://dejavu.mmckenna.me/causality-analysis/) — understanding why composables recompose
+- [Use Cases](https://dejavu.mmckenna.me/latest/use-cases/) — locking in UI efficiency, AI agent guardrails, and CI enforcement
+- [Examples](https://dejavu.mmckenna.me/latest/examples/) — test patterns for common scenarios
+- [Error Messages Guide](https://dejavu.mmckenna.me/latest/error-messages/) — how to read and act on failure output
+- [Causality Analysis](https://dejavu.mmckenna.me/latest/causality-analysis/) — understanding why composables recompose
 
 ## Contributing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -71,3 +71,35 @@ behavior across those releases.
    before announcing.
 10. Set the next development version to `X.Y.Z-SNAPSHOT` after publication, as in
    [Coil's release checklist](https://github.com/coil-kt/coil/blob/main/RELEASING.md).
+11. Verify the Docs workflow succeeded and inspect the live site's home, getting-started,
+    compatibility, release, and generated API pages. Check `versions.json`: `latest` must point
+    to the published release and `snapshot` to the next development version. Follow an old
+    unversioned guide URL too; it must redirect to `latest`, not serve an archived guide.
+
+## Documentation maintenance
+
+Keep `extra.dejavu_release` in `mkdocs.yml`, README and guide dependency examples, bundled
+onboarding instructions, and the compatibility matrix aligned with the published stable release.
+When bundled skill instructions change, advance both `.claude-plugin` manifest versions together
+so installed copies can receive the update; the plugin has its own version sequence.
+Keep historical release notes unchanged except for corrections and verified publication evidence.
+The site exposes release notes, migration guidance, validation records, and contribution policies
+in its navigation. A strict MkDocs build and `validation/docs.py verify site` check local files,
+anchors, API output, and stable dependency references before deployment.
+
+Documentation corrections can be shipped without a new Maven release. When `main` still has
+the released library source, API signatures, and dependency catalog, run:
+
+```bash
+gh workflow run docs.yml --ref main -f release_version=X.Y.Z
+```
+
+This refreshes the current stable site's guides and generates API docs labelled with the release
+version and linked to its tag. A guard refuses to relabel changed library APIs or dependencies
+as an existing release. If runtime development has moved on, apply the documentation correction
+on the matching release source instead; do not bypass that guard.
+
+To refresh development docs, run `gh workflow run docs.yml --ref main` without `release_version`.
+Snapshot pages identify themselves as unreleased and continue to show the stable dependency in
+install examples. The workflow also refreshes redirects from old unversioned guide URLs.
+It does not publish library artifacts or run the UI matrix.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,9 @@
 
 Dejavu is a library for Jetpack Compose recomposition tracking, designed for test-time use. Consumers scope it to the appropriate build configuration (e.g., `debugImplementation` or `testImplementation`).
 
-Dejavu does not handle user data, network requests, authentication, or any sensitive operations.
+Dejavu does not provide networking or authentication. Its diagnostics can include inspected UI state
+and parameter values, so remove sensitive values before sharing test logs or reproductions.
 
 ## Reporting
 
-If you discover a security concern related to Dejavu, please open a [GitHub issue](https://github.com/himattm/dejavu/issues). Since this library is designed for test-time use, standard issue reporting is appropriate.
+If you discover a security concern related to Dejavu, please open a [GitHub issue](https://github.com/mttmcknn/dejavu/issues). Since this library is designed for test-time use, standard issue reporting is appropriate.

--- a/dejavu/Module.md
+++ b/dejavu/Module.md
@@ -8,5 +8,8 @@ without per-composable setup.
 
 ## Getting started
 
-Add the dependency and call `Dejavu.enable()` before your test's `setContent()`.
+Add Dejavu to your test dependencies. On Android, use `createRecompositionTrackingRule()` and
+set the screen with the rule's `setContent`, or use the activity overload to launch your screen.
+On JVM, iOS, and Wasm, return `runRecompositionTrackingUiTest` directly from your test and call
+`setTrackedContent` inside it. These helpers manage tracking and cleanup automatically.
 See the [Getting Started guide](https://dejavu.mmckenna.me/latest/getting-started/) for details.

--- a/dejavu/build.gradle.kts
+++ b/dejavu/build.gradle.kts
@@ -220,7 +220,7 @@ mavenPublishing {
   pom {
     name.set("Dejavu")
     description.set("Implicit recomposition tracking for Jetpack Compose UI tests")
-    url.set("https://github.com/himattm/dejavu")
+    url.set("https://github.com/mttmcknn/dejavu")
     licenses {
       license {
         name.set("The Apache License, Version 2.0")
@@ -229,27 +229,30 @@ mavenPublishing {
     }
     developers {
       developer {
-        id.set("himattm")
+        id.set("mttmcknn")
         name.set("Matt McKenna")
         url.set("https://blog.mmckenna.me")
       }
     }
     scm {
-      url.set("https://github.com/himattm/dejavu")
-      connection.set("scm:git:git://github.com/himattm/dejavu.git")
-      developerConnection.set("scm:git:ssh://github.com/himattm/dejavu.git")
+      url.set("https://github.com/mttmcknn/dejavu")
+      connection.set("scm:git:git://github.com/mttmcknn/dejavu.git")
+      developerConnection.set("scm:git:ssh://github.com/mttmcknn/dejavu.git")
     }
   }
 }
 
 dokka {
   dokkaPublications.html {
+    moduleVersion.set(providers.gradleProperty("docsVersion").orElse(project.version.toString()))
+    includes.from("Module.md")
     outputDirectory.set(rootProject.layout.projectDirectory.dir("docs/api"))
   }
   dokkaSourceSets.configureEach {
     sourceLink {
       localDirectory.set(projectDir.resolve("src"))
-      remoteUrl("https://github.com/himattm/dejavu/blob/main/dejavu/src")
+      val sourceRef = providers.gradleProperty("docsSourceRef").orElse("main").get()
+      remoteUrl("https://github.com/mttmcknn/dejavu/blob/$sourceRef/dejavu/src")
       remoteLineSuffix.set("#L")
     }
     documentedVisibilities(

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,18 @@
+# Contributing
+
+DejaVu is a recomposition testing library. Intentionally inefficient fixtures are part of its
+contract: tests compare measured counts with independent unkeyed `SideEffect` counters and
+verify expected budget failures. Preserve those fixtures when contributing.
+
+- [Development setup and test commands](https://github.com/mttmcknn/dejavu/blob/main/CONTRIBUTING.md)
+- [Report a reproducible bug](https://github.com/mttmcknn/dejavu/issues/new?template=bug_report.md)
+- [Propose a feature](https://github.com/mttmcknn/dejavu/issues/new?template=feature_request.md)
+- [Release checklist](https://github.com/mttmcknn/dejavu/blob/main/RELEASING.md)
+- [Code of conduct](https://github.com/mttmcknn/dejavu/blob/main/CODE_OF_CONDUCT.md)
+- [Security policy](https://github.com/mttmcknn/dejavu/blob/main/SECURITY.md)
+- [Apache 2.0 license](https://github.com/mttmcknn/dejavu/blob/main/LICENSE)
+
+Include your DejaVu version, Compose BOM or Multiplatform version, Kotlin version, platform,
+reproduction, and expected count when reporting a bug. Record test environments and actual
+results in pull requests. Passing equivalent local checks can replace budget-constrained hosted
+CI; reproduced product failures must still be fixed.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,38 +1,117 @@
 # Getting Started
 
-## 1. Add dependency
+## Choose a compatible release
+
+The latest stable release is **0.5.0**, built against Compose Multiplatform **1.12.0** and
+Android BOM **2026.08.00**. Android consumers need **compile SDK 37** and **min SDK 24**.
+The release was validated with Kotlin 2.4.0 and its Compose compiler plugin.
+
+Android Compose 1.11 remains supported when you enforce its BOM in both application and
+instrumentation dependencies. Use 0.4.0 for the Compose Multiplatform 1.11 / compile SDK 36
+baseline, or 0.3.1 for Compose 1.10. See [versions and migration](releases/index.md).
+
+## Android setup
+
+Add the test dependency to your app module. The plain rule also needs Compose's test activity
+manifest in the debug variant:
 
 ```kotlin
 // app/build.gradle.kts
+android {
+    compileSdk = 37
+}
+
 dependencies {
+    val composeBom = enforcedPlatform("androidx.compose:compose-bom:2026.08.00")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
     androidTestImplementation("me.mmckenna.dejavu:dejavu:0.5.0")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
 }
 ```
 
-## 2. Write a test
+To retain Android Compose 1.11, select the validated BOM `2026.05.00` or `2026.06.01` in
+that same enforced-platform declaration. Keep compile SDK 37 for the 0.5.0 Android artifact.
+
+This complete test sets content, resets the budget, and then measures one state change:
 
 ```kotlin
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.onNodeWithTag
 import dejavu.assertRecompositions
-import dejavu.assertStable
 import dejavu.createRecompositionTrackingRule
+import dejavu.resetRecompositionCounts
+import org.junit.Rule
+import org.junit.Test
 
-@get:Rule
-val composeTestRule = createRecompositionTrackingRule()
+class CounterRecompositionTest {
+    @get:Rule
+    val composeTestRule = createRecompositionTrackingRule()
 
-@Test
-fun incrementCounter_onlyValueRecomposes() {
-    composeTestRule.onNodeWithTag("inc_button")
-        .performClick()
-    composeTestRule.onNodeWithTag("counter_value")
-        .assertRecompositions(exactly = 1)
-    composeTestRule.onNodeWithTag("counter_title")
-        .assertStable() // stable = zero recompositions
+    @Test
+    fun counterRecomposesOnce() {
+        val count = mutableIntStateOf(0)
+        composeTestRule.setContent { CounterValue(count.intValue) }
+        composeTestRule.waitForIdle()
+        composeTestRule.resetRecompositionCounts()
+
+        composeTestRule.runOnIdle { count.intValue++ }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("counter_value")
+            .assertRecompositions(exactly = 1)
+    }
+}
+
+@Composable
+private fun CounterValue(value: Int) {
+    BasicText("Value: $value", modifier = Modifier.testTag("counter_value"))
 }
 ```
 
-`createRecompositionTrackingRule` wraps `createAndroidComposeRule` and resets counts before each test. For `createComposeRule()` or other rule types, see [Examples](examples.md).
+For a screen owned by your app activity, use `createRecompositionTrackingRule<YourActivity>()`.
+The rule launches that activity and manages Dejavu's lifecycle. See [Examples](examples.md) for
+larger scenarios and `assertStable()` expectations.
 
-To reset counts mid-test — after initial composition but before the interaction you want to measure — call `composeTestRule.resetRecompositionCounts()`. On non-Android targets (JVM, iOS, WasmJs), the same helper is available as `resetRecompositionCounts()` inside `runRecompositionTrackingUiTest`.
+## Kotlin Multiplatform setup
+
+Add the dependency to the shared test source set for JVM desktop, iOS arm64 and simulator arm64,
+and WasmJs. Use the Compose Multiplatform 1.12.0 baseline for 0.5.0:
+
+```kotlin
+kotlin {
+    sourceSets {
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+            implementation("me.mmckenna.dejavu:dejavu:0.5.0")
+        }
+    }
+}
+```
+
+Return the helper's result directly so the Wasm test runner waits for completion:
+
+```kotlin
+import androidx.compose.ui.test.onNodeWithTag
+import dejavu.assertStable
+import dejavu.runRecompositionTrackingUiTest
+import dejavu.setTrackedContent
+import kotlin.test.Test
+
+@Test
+fun counterStartsStable() = runRecompositionTrackingUiTest {
+    setTrackedContent { CounterValue(0) }
+    waitForIdle()
+    onNodeWithTag("counter_value").assertStable()
+}
+```
+
+This uses the `CounterValue` composable above. Keep assertions inside the suspending helper body.
+Call `resetRecompositionCounts()` after settling initial content and before the interaction whose
+budget you want to measure. The helper manages tracking and cleanup automatically.
 
 ## What a Failure Looks Like
 
@@ -62,8 +141,8 @@ See the [Error Messages Guide](error-messages.md) for how to read and act on eac
 If you use Claude Code, you can install the bundled Dejavu skills globally so they're available in any project. The skill set covers the full lifecycle: `dejavu-onboarding` (initial install), `dejavu-test-writer` (author tests), `dejavu-error-triage` (diagnose a single failure), and `dejavu-perf-loop` (iteratively optimize a composable's recomposition behavior using Dejavu as the validator).
 
 ```
-/plugin marketplace add himattm/dejavu
+/plugin marketplace add mttmcknn/dejavu
 /plugin install dejavu@dejavu
 ```
 
-Sessions opened inside the [Dejavu repo](https://github.com/himattm/dejavu) auto-load the same skills from `.claude/skills/` without installing the plugin. See [Use Cases → Give AI Agents a Recomposition Signal](use-cases.md#give-ai-agents-a-recomposition-signal) for what the skills do in practice.
+Sessions opened inside the [Dejavu repo](https://github.com/mttmcknn/dejavu) auto-load the same skills from `.claude/skills/` without installing the plugin. See [Use Cases → Give AI Agents a Recomposition Signal](use-cases.md#give-ai-agents-a-recomposition-signal) for what the skills do in practice.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -8,7 +8,8 @@ Dejavu hooks into the Compose runtime's `CompositionTracer` API (available since
 4. **Tracks causality** — `Snapshot.registerApplyObserver` detects state changes; dirty bits detect parameter-driven recompositions
 5. **Reports on failure** — assembles source location, timeline, tracked composables, and causality into a structured error
 
-All tracking runs in the app process on the main thread, directly accessible to instrumented tests.
+On Android, tracking runs in the app process and is accessible to instrumented tests. JVM, iOS,
+and Wasm tests use the shared tracer through `runRecompositionTrackingUiTest`.
 
 ## Compatibility
 
@@ -30,7 +31,7 @@ is Compose 1.11 (BOM 2026.05.00). CI derives its matrix from the `composeBomComp
 Multiplatform artifacts cannot silently replace the runtime under test. `CompositionObserver`
 support is unconditional; there is no degraded or observer-excluded build path.
 
-Android 0.5.0 artifacts declare minimum compile SDK 37. To retain an older Android Compose line,
+Android 0.5.0 artifacts require compile SDK 37 and min SDK 24. To retain an older Android Compose line,
 use `enforcedPlatform` for the selected BOM in both application and instrumentation dependencies;
 a regular platform can allow the newer transitive baseline to win. DejaVu 0.4.0 remains the
 Compose Multiplatform 1.11 / compile SDK 36 baseline.
@@ -67,6 +68,7 @@ Compose 1.12. These methods require 1.12; the existing rule API remains covered 
 ## Known Limitations
 
 - **Off-screen lazy items** — `LazyColumn`/`LazyRow` only compose items that are visible. Items that haven't been composed don't exist in the composition tree, so Dejavu has nothing to track. Scroll them into view before asserting.
+- **Non-Android instance diagnostics** — unresolved tags can share a function-level count when multiple instances use the same composable. Android has the most complete per-instance diagnostics.
 - **Activity-owned Recomposer clock** — `createAndroidComposeRule` uses the Activity's real `Recomposer`, not a test-controlled one. This means `mainClock.advanceTimeBy()` can't drive infinite animations forward. Use `createComposeRule` (without an Activity) if you need a controllable clock.
 - **Parameter change tracking precision** — parameter diffs use `Group.parameters` from the Compose tooling data API, which was designed for Layout Inspector rather than programmatic diffing. Parameter names may be unavailable, and values are compared via `hashCode`/`toString`, so custom types without meaningful `toString` show opaque values.
 - **iOS x64** — Compose Multiplatform 1.11 removes Apple x64 target support, so Dejavu supports `iosArm64` and `iosSimulatorArm64` for the 1.11 baseline.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,12 +2,12 @@
 
 *Wait... didn't we just compose this?*
 
-[![CI](https://github.com/himattm/dejavu/actions/workflows/ci.yml/badge.svg)](https://github.com/himattm/dejavu/actions/workflows/ci.yml)
+[![CI](https://github.com/mttmcknn/dejavu/actions/workflows/ci.yml/badge.svg)](https://github.com/mttmcknn/dejavu/actions/workflows/ci.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/me.mmckenna.dejavu/dejavu)](https://central.sonatype.com/artifact/me.mmckenna.dejavu/dejavu)
-[![Compose](https://img.shields.io/badge/Compose-1.11%2B-4285F4?logo=jetpackcompose&logoColor=white)](https://developer.android.com/develop/ui/compose)
+[![Compose](https://img.shields.io/badge/Compose-1.11–1.12-4285F4?logo=jetpackcompose&logoColor=white)](https://developer.android.com/develop/ui/compose)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-**[GitHub Repository](https://github.com/himattm/dejavu)**
+**[GitHub Repository](https://github.com/mttmcknn/dejavu)**
 
 **Guard your Compose UI efficiency. Catch recomposition regressions before your users.**
 
@@ -41,15 +41,17 @@ recomposition coverage) validates Dejavu against Compose 1.11's new composables 
 - [Getting Started](getting-started.md) — add the dependency and write your first test
 - [Use Cases](use-cases.md) — locking in UI efficiency, AI agent guardrails, and CI enforcement
 - [Examples](examples.md) — test patterns for common scenarios
-- [API Reference](api-reference.md) — all assertions and utilities
+- [API Reference](api/index.html) — all assertions and utilities
 - [How It Works](how-it-works.md) — internals, compatibility, and limitations
+- [Releases and migration](releases/index.md) — supported versions, release notes, and validation
+- [Contributing](contributing.md) — development setup, test expectations, and project policies
 
 ## Using Claude Code?
 
 Install the bundled Dejavu skills globally — they cover initial install (`dejavu-onboarding`), authoring tests (`dejavu-test-writer`), diagnosing single failures (`dejavu-error-triage`), and the iterative perf-optimization loop (`dejavu-perf-loop`):
 
 ```
-/plugin marketplace add himattm/dejavu
+/plugin marketplace add mttmcknn/dejavu
 /plugin install dejavu@dejavu
 ```
 

--- a/docs/releases/0.5.0.md
+++ b/docs/releases/0.5.0.md
@@ -66,7 +66,7 @@ Android checkpoints with an adapter for the changed experimental Styles API.
 ## Packaged artifact checks
 
 All six 0.5.0 Maven publications were built locally once at the 1.12 baseline. The standalone
-[consumer build](../../validation/consumer/README.md) consumes those artifacts rather than
+[consumer build](https://github.com/mttmcknn/dejavu/blob/v0.5.0/validation/consumer/README.md) consumes those artifacts rather than
 recompiling the DejaVu source for each older runtime.
 
 ```bash

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -1,0 +1,44 @@
+# Releases and migration
+
+**Latest stable: [DejaVu 0.5.0](https://github.com/mttmcknn/dejavu/releases/tag/v0.5.0).**
+All six Maven Central publications are available. Dependency examples use the stable release.
+
+| DejaVu | Compose Multiplatform baseline | Android Compose | Android compile SDK |
+|---|---|---|---|
+| [0.5.0](https://github.com/mttmcknn/dejavu/releases/tag/v0.5.0) | 1.12.0 | 1.11–1.12 | 37 |
+| [0.4.0](https://github.com/mttmcknn/dejavu/releases/tag/v0.4.0) | 1.11.1 | 1.11 | 36 |
+| [0.3.1](https://github.com/mttmcknn/dejavu/releases/tag/v0.3.1) | 1.10.3 | 1.10 | See versioned docs |
+
+Use the [compatibility matrix](../how-it-works.md#compatibility) for exact Android BOM checkpoints.
+With 0.5.0, retain an older Android BOM using `enforcedPlatform` in both app and instrumentation
+dependencies; a regular platform can resolve the newer transitive baseline. The Android artifact
+still requires compile SDK 37. The new `hasPendingWork` and `runWithoutImplicitWait` rule methods
+require Compose 1.12.
+
+Since 0.4.0, return `runRecompositionTrackingUiTest` directly from KMP tests and keep assertions
+inside its suspending body. This lets Wasm await completion and observe failures. Recompile test
+modules when upgrading from older helper signatures.
+
+0.5.0 fixes tracking lifecycle transitions when Android rules and the KMP helper share one
+instrumentation process. The limitation remains documented for 0.4.0.
+
+## Validation and history
+
+- [0.5.0 validation](0.5.0.md): Android, JVM, iOS, Wasm, and packaged consumer checks.
+- [0.4.0 validation](0.4.0.md): restored async Wasm and lazy-layout coverage.
+- [Changelog](https://github.com/mttmcknn/dejavu/blob/main/CHANGELOG.md).
+- [All GitHub releases](https://github.com/mttmcknn/dejavu/releases).
+
+The site version selector keeps released documentation available. `latest` follows the current
+stable release; `snapshot` follows unreleased development and can describe APIs not in Maven
+Central yet. Historical release pages intentionally keep their original dependency versions.
+
+## Release policy
+
+DejaVu uses independent semantic versions, pins one stable Compose Multiplatform baseline per
+release, and tests an Android BOM compatibility window. We follow stable Compose releases;
+alpha and beta updates do not automatically trigger DejaVu releases. Moving the compatibility
+floor requires an explicit release and migration note.
+
+See the [maintainer release checklist](https://github.com/mttmcknn/dejavu/blob/main/RELEASING.md)
+for local validation, artifact verification, and documentation publication.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -53,11 +53,11 @@ For Claude Code users, Dejavu ships four skills as a Claude Code plugin so the a
 Install:
 
 ```
-/plugin marketplace add himattm/dejavu
+/plugin marketplace add mttmcknn/dejavu
 /plugin install dejavu@dejavu
 ```
 
-Sessions opened inside the [Dejavu repo](https://github.com/himattm/dejavu) auto-load the same skills from `.claude/skills/` without installing the plugin.
+Sessions opened inside the [Dejavu repo](https://github.com/mttmcknn/dejavu) auto-load the same skills from `.claude/skills/` without installing the plugin.
 
 ### Programmatic checks
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,12 @@
 site_name: Dejavu
 site_description: Lock in Compose UI efficiency. Catch recomposition regressions before your users.
 site_url: https://dejavu.mmckenna.me
-repo_url: https://github.com/himattm/dejavu
-repo_name: himattm/dejavu
+repo_url: https://github.com/mttmcknn/dejavu
+repo_name: mttmcknn/dejavu
 edit_uri: edit/main/docs/
+strict: true
+hooks:
+  - validation/docs_hook.py
 
 theme:
   name: material
@@ -37,12 +40,18 @@ theme:
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
-  - Use Cases: use-cases.md
-  - Examples: examples.md
+  - Guides:
+      - Use Cases: use-cases.md
+      - Examples: examples.md
+      - How It Works: how-it-works.md
+      - Error Messages: error-messages.md
+      - Causality Analysis: causality-analysis.md
   - 'API Reference ↗': api/index.html
-  - How It Works: how-it-works.md
-  - Error Messages: error-messages.md
-  - Causality Analysis: causality-analysis.md
+  - Releases:
+      - Versions and migration: releases/index.md
+      - 0.5.0 validation: releases/0.5.0.md
+      - 0.4.0 validation: releases/0.4.0.md
+  - Contributing: contributing.md
 
 markdown_extensions:
   - admonition
@@ -55,11 +64,13 @@ markdown_extensions:
   - attr_list
 
 plugins:
+  - search
   - mike
 
 extra:
+  dejavu_release: 0.5.0
   version:
     provider: mike
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/himattm/dejavu
+      link: https://github.com/mttmcknn/dejavu

--- a/validation/docs.py
+++ b/validation/docs.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Validate documentation releases, local links, and legacy website redirects."""
+import argparse
+import html
+import re
+import subprocess
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+ROOT = Path(__file__).resolve().parents[1]
+VERSION = re.compile(r'^version = "([^"]+)"', re.M)
+
+
+def git(*args):
+    return subprocess.check_output(['git', *args], cwd=ROOT, text=True).strip()
+
+
+def documentation_version(ref, release):
+    current = VERSION.search((ROOT / 'dejavu/build.gradle.kts').read_text()).group(1)
+    if release:
+        if ref != 'refs/heads/main':
+            raise ValueError('Release documentation corrections must run from main.')
+        if not re.fullmatch(r'\d+\.\d+\.\d+', release):
+            raise ValueError('release_version must be a stable X.Y.Z version.')
+        stable = re.search(r'^  dejavu_release: (\S+)', (ROOT / 'mkdocs.yml').read_text(), re.M).group(1)
+        if release != stable:
+            raise ValueError('Only the current stable documentation may be refreshed from main.')
+        tag = f'v{release}'
+        tagged = VERSION.search(git('show', f'{tag}:dejavu/build.gradle.kts')).group(1)
+        if tagged != release:
+            raise ValueError('Release tag and published Gradle version differ.')
+        # Do not label new runtime APIs or dependencies as an already released version.
+        changed = git('diff', '--name-only', tag, '--', 'dejavu/src', 'dejavu/api', 'gradle/libs.versions.toml')
+        if changed:
+            raise ValueError(f'Release API or dependencies changed; generate docs from the release source instead:\n{changed}')
+        return release
+    if ref.startswith('refs/tags/v'):
+        if ref.removeprefix('refs/tags/v') != current or current.endswith('-SNAPSHOT'):
+            raise ValueError('Documentation tag must match the Gradle release version.')
+    elif ref != 'refs/heads/main' or not current.endswith('-SNAPSHOT'):
+        raise ValueError('Development documentation requires main and a SNAPSHOT version.')
+    return current
+
+
+class Page(HTMLParser):
+    def __init__(self, text):
+        super().__init__()
+        self.links = []
+        self.ids = set()
+        self.feed(text)
+
+    def handle_starttag(self, tag, attrs):
+        attrs = dict(attrs)
+        if 'id' in attrs:
+            self.ids.add(attrs['id'])
+        if tag == 'a' and 'href' in attrs:
+            self.links.append(attrs['href'])
+
+
+def verify(site):
+    site = Path(site).resolve()
+    pages = {p: Page(p.read_text()) for p in site.rglob('*.html')}
+    if site / 'api/index.html' not in pages:
+        raise ValueError('Generate the API documentation before building the site.')
+    failures = []
+    for path, page in pages.items():
+        for href in page.links:
+            url = urlsplit(href)
+            if url.scheme or url.netloc or url.path.startswith('/'):
+                continue
+            target = (path.parent / unquote(url.path)).resolve() if url.path else path
+            if target.is_dir():
+                target /= 'index.html'
+            if not target.is_relative_to(site):
+                failures.append(f'{path.relative_to(site)}: outside site: {href}')
+            elif not target.exists():
+                failures.append(f'{path.relative_to(site)}: missing file: {href}')
+            elif (url.fragment and target in pages
+                  and url.fragment not in pages[target].ids
+                  and unquote(url.fragment) not in pages[target].ids):
+                failures.append(f'{path.relative_to(site)}: missing anchor: {href}')
+    stable = re.search(r'^  dejavu_release: (\S+)', (ROOT / 'mkdocs.yml').read_text(), re.M).group(1)
+    current_docs = [ROOT / 'README.md', *ROOT.glob('docs/*.md'), ROOT / '.claude/skills/dejavu-onboarding/SKILL.md']
+    for path in current_docs:
+        for version in re.findall(r'me\.mmckenna\.dejavu:dejavu:([\d.]+(?:-SNAPSHOT)?)', path.read_text()):
+            if version != stable:
+                failures.append(f'{path.relative_to(ROOT)}: dependency {version} differs from stable {stable}')
+    if failures:
+        raise ValueError('\n'.join(sorted(set(failures))))
+    print(f'PASS: {len(pages)} HTML pages, local links and anchors, API output, and stable dependency examples.')
+
+
+def redirect(path, target):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    escaped = html.escape(target, quote=True)
+    path.write_text(f'<!doctype html><html lang="en"><head><meta charset="utf-8">'
+                    f'<title>DejaVu documentation</title><link rel="canonical" href="{escaped}">'
+                    f'<meta http-equiv="refresh" content="0; url={escaped}"></head>'
+                    f'<body><a href="{escaped}">Continue to the latest DejaVu documentation</a>'
+                    f'<script>location.replace({target!r}+location.hash)</script></body></html>\n')
+
+
+def repair_api(destination):
+    # Dokka 2.2 merges inherited overloads into one row but can retain links to
+    # individual anchors it never emits. Point those links at their containing row.
+    repaired = 0
+    for path in Path(destination).rglob('*.html'):
+        original = path.read_text()
+        ids = Page(original).ids
+        def row(match):
+            nonlocal repaired
+            anchor, content = match.group(1), match.group(0)
+            if anchor not in ids:
+                return content
+            def link(found):
+                nonlocal repaired
+                target = found.group(1)
+                if target in ids or unquote(target) in ids:
+                    return found.group(0)
+                repaired += 1
+                return f'href="index.html#{anchor}"'
+            return re.sub(r'href="index.html#([^"]+)"', link, content)
+        updated = re.sub(r'<a data-name="([^"]+)".*?(?=<a data-name="|\Z)', row, original, flags=re.S)
+        if updated != original:
+            path.write_text(updated)
+    print(f'Repaired {repaired} Dokka links to merged overload rows.')
+
+
+def redirects(destination):
+    destination = Path(destination)
+    routes = ['getting-started', 'examples', 'use-cases', 'how-it-works', 'error-messages', 'causality-analysis']
+    for route in routes:
+        redirect(destination / route / 'index.html', f'https://dejavu.mmckenna.me/latest/{route}/')
+    for route in ['api-reference', 'api']:
+        redirect(destination / route / 'index.html', 'https://dejavu.mmckenna.me/latest/api/index.html')
+    print(f'Updated {len(routes) + 2} legacy documentation redirects.')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest='command', required=True)
+    version = commands.add_parser('version')
+    version.add_argument('--ref', default='refs/heads/main')
+    version.add_argument('--release', default='')
+    commands.add_parser('verify').add_argument('site')
+    commands.add_parser('repair-api').add_argument('destination')
+    commands.add_parser('redirects').add_argument('destination')
+    args = parser.parse_args()
+    try:
+        if args.command == 'version':
+            print(documentation_version(args.ref, args.release))
+        elif args.command == 'verify':
+            verify(args.site)
+        elif args.command == 'repair-api':
+            repair_api(args.destination)
+        else:
+            redirects(args.destination)
+    except (ValueError, subprocess.CalledProcessError) as error:
+        parser.exit(1, f'{error}\n')

--- a/validation/docs_hook.py
+++ b/validation/docs_hook.py
@@ -1,0 +1,12 @@
+"""Identify development guides without rewriting stable dependency snippets."""
+import os
+
+
+def on_page_markdown(markdown, page, config, files):
+    version = os.environ.get('DEJAVU_DOCS_VERSION', '')
+    if version.endswith('-SNAPSHOT'):
+        return (f'!!! warning "Development documentation: {version}"\n'
+                '    These guides may describe unreleased APIs. '
+                '[Read the latest stable documentation](https://dejavu.mmckenna.me/latest/). '
+                'Dependency examples remain on the published stable release.\n\n' + markdown)
+    return markdown


### PR DESCRIPTION
Old unversioned guide URLs still served DejaVu 0.1.1 instructions, the snapshot alias remained on 0.4.0-SNAPSHOT, and the home page linked to a missing API reference. This updates installation and contributor guidance for 0.5.0, adds searchable release and contribution pages, corrects canonical repository links, and redirects legacy guide URLs to the current stable docs.

The Docs workflow now validates local links, anchors, API output, and stable dependency examples before deployment. It can refresh current stable docs from main only while library source, public signatures, and dependencies still match the release tag. API version labels and source links follow the documented release; snapshot guides are labelled as development. Dokka's missing inherited-overload anchors are redirected to their existing containing rows. Bundled onboarding compatibility guidance is corrected and the skills plugin version advances to 0.2.0.

Validation: Dokka generation and `verifyComposeBomConfiguration` passed; strict MkDocs builds and checks passed for 32 HTML pages; a deliberately broken-link canary was rejected; development banners, release API labels/source links, stable dependency examples, workflow actionlint, and whitespace checks passed. No library runtime or public API changes, and no repeat of the UI matrix.

After merge: dispatch Docs once for release_version=0.5.0 and once for the current main snapshot, then verify live aliases, old URL redirects, search, and API navigation.
