### PR TITLE
Make installation examples complete and verify them against 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,14 @@ See [Compatibility](#compatibility) before adding the dependency to an older Com
 // app/build.gradle.kts
 dependencies {
     androidTestImplementation("me.mmckenna.dejavu:dejavu:0.5.0")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
 }
 ```
+
+Use your enforced Compose BOM for the unversioned Compose test artifacts. See the
+[complete setup](https://dejavu.mmckenna.me/latest/getting-started/) for the runner, compatible
+Android test dependencies, and KMP source sets.
 
 ### 2. Write a test
 
@@ -234,6 +240,7 @@ Dejavu supports Kotlin Multiplatform with the following targets:
 For non-Android platforms, use `runRecompositionTrackingUiTest` with `setTrackedContent`:
 
 ```kotlin
+@OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
 @Test
 fun myComposable_isStable() = runRecompositionTrackingUiTest {
     setTrackedContent { MyComposable() }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,16 +19,28 @@ manifest in the debug variant:
 // app/build.gradle.kts
 android {
     compileSdk = 37
+    defaultConfig {
+        minSdk = 24
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
 }
+
+composeCompiler { includeSourceInformation = true }
 
 dependencies {
     val composeBom = enforcedPlatform("androidx.compose:compose-bom:2026.08.00")
     implementation(composeBom)
     androidTestImplementation(composeBom)
     androidTestImplementation("me.mmckenna.dejavu:dejavu:0.5.0")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    androidTestImplementation("androidx.test.ext:junit:1.3.0")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 }
 ```
+
+Compose test APIs are compile-only dependencies of DejaVu, so include them explicitly in your
+test module. The Espresso version above matches the API 37 validation environment.
 
 To retain Android Compose 1.11, select the validated BOM `2026.05.00` or `2026.06.01` in
 that same enforced-platform declaration. Keep compile SDK 37 for the 0.5.0 Android artifact.
@@ -87,10 +99,17 @@ kotlin {
         commonTest.dependencies {
             implementation(kotlin("test"))
             implementation("me.mmckenna.dejavu:dejavu:0.5.0")
+            implementation(compose.foundation)
+            @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+            implementation(compose.uiTest)
         }
     }
 }
 ```
+
+Keep `composeCompiler { includeSourceInformation = true }` enabled in the shared module.
+For desktop tests, also add `implementation(compose.desktop.currentOs)` to `jvmTest.dependencies`.
+The Compose Multiplatform plugin supplies the `compose` dependency accessors above.
 
 Return the helper's result directly so the Wasm test runner waits for completion:
 
@@ -101,11 +120,14 @@ import dejavu.runRecompositionTrackingUiTest
 import dejavu.setTrackedContent
 import kotlin.test.Test
 
-@Test
-fun counterStartsStable() = runRecompositionTrackingUiTest {
-    setTrackedContent { CounterValue(0) }
-    waitForIdle()
-    onNodeWithTag("counter_value").assertStable()
+@OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+class CounterMultiplatformTest {
+    @Test
+    fun counterStartsStable() = runRecompositionTrackingUiTest {
+        setTrackedContent { CounterValue(0) }
+        waitForIdle()
+        onNodeWithTag("counter_value").assertStable()
+    }
 }
 ```
 


### PR DESCRIPTION
Installation examples now explicitly include the Compose UI test dependencies that DejaVu declares compile-only. Android setup includes the runner, test activity manifest, source information, and the Android test dependency versions used by release validation. KMP setup includes Compose UI testing, the desktop runtime, an actual test class, and the required experimental test API opt-in.

Validation: extracted the documented Kotlin examples into the standalone consumer of released DejaVu 0.5.0. Android example passed on API 37; JVM consumer plus KMP example passed 2 tests, with no failures or skips. Android test sources compiled. Strict documentation build and all 32 HTML-page link checks passed. Temporary extracted test files were removed after preserving reports. No runtime changes.

Publish these guide corrections to stable and snapshot documentation after merge using the locally validated documentation tools, avoiding another hosted test matrix.
