### PR TITLE
Keep GitHub links current across all documentation versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,6 +71,7 @@ jobs:
           python3 validation/docs.py repair-api docs/api
           mkdocs build --strict
           python3 validation/docs.py verify site
+          python3 validation/update_github_links.py site --check
 
       - name: Deploy documentation
         env:
@@ -81,13 +82,15 @@ jobs:
             mike set-default --push latest
           fi
 
-      - name: Refresh unversioned guide redirects
+      - name: Refresh website links across all versions
         run: |
           git worktree add build/docs-pages gh-pages
           python3 validation/docs.py redirects build/docs-pages
-          git -C build/docs-pages add getting-started examples use-cases how-it-works error-messages causality-analysis api-reference api
+          python3 validation/update_github_links.py build/docs-pages
+          python3 validation/update_github_links.py build/docs-pages --check
+          git -C build/docs-pages add --all
           if ! git -C build/docs-pages diff --cached --quiet; then
-            git -C build/docs-pages commit -m "Point unversioned guides to latest documentation"
+            git -C build/docs-pages commit -m "Refresh documentation redirects and GitHub links"
             git -C build/docs-pages push origin gh-pages
           fi
           git worktree remove build/docs-pages

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -103,3 +103,8 @@ To refresh development docs, run `gh workflow run docs.yml --ref main` without `
 Snapshot pages identify themselves as unreleased and continue to show the stable dependency in
 install examples. The workflow also refreshes redirects from old unversioned guide URLs.
 It does not publish library artifacts or run the UI matrix.
+
+GitHub account links must also stay current in archived releases and the root 404 page. The
+Docs workflow checks the new build and updates GitHub references across the full `gh-pages`
+tree with `validation/update_github_links.py`. This only changes the account name; historical
+dependency versions, API content, and version aliases remain intact.

--- a/validation/update_github_links.py
+++ b/validation/update_github_links.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Keep GitHub links current across the entire published documentation archive."""
+import argparse
+import re
+from pathlib import Path
+
+OLD_OWNER = re.compile(rb"\bhimattm\b", re.IGNORECASE)
+NEW_OWNER = b"mttmcknn"
+TEXT_SUFFIXES = {".html", ".json", ".xml", ".txt", ".md", ".js", ".css", ".svg"}
+
+
+def update(root, check=False):
+    changed = []
+    occurrences = 0
+    for path in sorted(Path(root).rglob("*")):
+        if path.is_symlink() or not path.is_file() or path.suffix not in TEXT_SUFFIXES:
+            continue
+        original = path.read_bytes()
+        updated, count = OLD_OWNER.subn(NEW_OWNER, original)
+        if count:
+            changed.append(path.relative_to(root))
+            occurrences += count
+            if not check:
+                path.write_bytes(updated)
+    if check and changed:
+        raise ValueError(f"Old GitHub account references in {len(changed)} published files: "
+                         + ", ".join(map(str, changed)))
+    print(f"{'Checked' if check else 'Updated'} published GitHub links: "
+          f"{len(changed)} files, {occurrences} old-account references.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", type=Path)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    if not args.root.is_dir():
+        parser.error("root must be an existing documentation directory")
+    try:
+        update(args.root, args.check)
+    except ValueError as error:
+        parser.exit(1, f"{error}\n")


### PR DESCRIPTION
Archived documentation and the root 404 page still contained the previous GitHub account name even though current source and latest docs had been updated. Corrected all 810 references across 190 published HTML pages, preserving historical dependency versions and version aliases.

Add a complete-archive link update to the Docs workflow and reject old account references in newly built documentation. This prevents the previous audit gap, which only checked current release routes.

Validation: the new check rejected the original archive, passed after correction, and passed for the current generated site. Every changed published file was verified to differ only by the requested account-name substitution. Actionlint and whitespace checks passed. No library or API changes; no UI matrix rerun.
